### PR TITLE
3: Implemented functionality to post annotated data to the server

### DIFF
--- a/covfee/client/tasks/continuous_annotation/continous_annotation.module.css
+++ b/covfee/client/tasks/continuous_annotation/continous_annotation.module.css
@@ -1,78 +1,79 @@
 .action-annotation-task {
-    display: flex;
-  }
+  display: flex;
+}
 
-  .gallery-overlay{
-    width: 100%;
-    height: 100%;
-    position: fixed;
-    top: 2%;
-    left: 0%;
-    background: rgba(49,49,49,0.9);
-    z-index: 1000;
-    overflow: auto;
-  }
+.gallery-overlay {
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 2%;
+  left: 0%;
+  background: rgba(49, 49, 49, 0.9);
+  z-index: 1000;
+  overflow: auto;
+}
 
-  .gallery-overlay h1{
-    color: white;
-    font-size: 2em;
-    text-align: center;
-    margin-top: 2%;
-  }
-  .gallery-overlay-image{
-    height: auto;
-    width: 95%;
-    position: absolute;
-    
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: white;
-    
-  }
+.gallery-overlay h1 {
+  color: white;
+  font-size: 2em;
+  text-align: center;
+  margin-top: 2%;
+}
+.gallery-overlay-image {
+  height: auto;
+  width: 95%;
+  position: absolute;
 
-  .sidebar {
-    font-size: 1em;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    width:20%; /* Adjust as needed */
-    min-width: 200px; /* Set a minimum width */
-    background-color: #f0f0f0; /* Example background color */
-    padding: 12px;
-  }
-  
-  .sidebar h1{
-    font-size: 1em;
-    margin-top: 2em;
-  }
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: white;
+}
 
-  .sidebarBottom {
-    margin-top: auto;
-    background-color: red;
-  }
+.sidebar {
+  font-size: 1em;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  width: 20%; /* Adjust as needed */
+  min-width: 200px; /* Set a minimum width */
+  background-color: #f0f0f0; /* Example background color */
+  padding: 12px;
+}
 
-  .gallery-button{
-    width: 100%;
-  }
+.sidebar h1 {
+  font-size: 1em;
+  margin-top: 2em;
+}
 
-  .main-content {
-    background-color: #ffffff; /* Example background color */
-    width: 80%;
-    flex-direction: column;
-  }
-  
-  .videoPlayer{
-    width: 50%;
-  }
+.sidebarBottom {
+  margin-top: auto;
+}
 
-.action-task-dropdown-title{
+.gallery-button {
+  font-size: 16px;
+  width: 100%;
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+.main-content {
+  background-color: #ffffff; /* Example background color */
+  width: 80%;
+  flex-direction: column;
+}
+
+.videoPlayer {
+  width: 50%;
+}
+
+.action-task-dropdown-title {
   text-align: left;
 }
-.action-task-dropwdown{
+.action-task-dropwdown {
   font-size: 30px;
 }
 
-.action-task-dropwdown-button{
+.action-task-dropwdown-button {
   width: 100%;
   border: 1px solid blue;
   border-radius: 6px;

--- a/covfee/client/tasks/continuous_annotation/slice.ts
+++ b/covfee/client/tasks/continuous_annotation/slice.ts
@@ -1,14 +1,12 @@
 import { createSlice } from "@reduxjs/toolkit"
 
 export interface State {
-  active_annotation?: string
-  active_participant?: string
+  selectedAnnotationIndex?: number | null
   mediaPaused: boolean
 }
 
 export const initialState: State = {
-  active_annotation: null,
-  active_participant: null,
+  selectedAnnotationIndex: null,
   mediaPaused: null,
 }
 
@@ -19,11 +17,8 @@ export const slice = createSlice({
     setMediaPaused: (state, action) => {
       state.mediaPaused = action.payload
     },
-    setActiveAnnotation: (state, action) => {
-      state.active_annotation = action.payload
-    },
-    setActiveParticipant: (state, action) => {
-      state.active_participant = action.payload
+    setSelectedAnnotationIndex: (state, action) => {
+      state.selectedAnnotationIndex = action.payload
     },
   },
 })

--- a/covfee/client/tasks/continuous_annotation/spec.ts
+++ b/covfee/client/tasks/continuous_annotation/spec.ts
@@ -2,6 +2,12 @@ import { BaseTaskSpec } from "@covfee-shared/spec/task"
 /**
  * @TJS-additionalProperties false
  */
+export interface AnnotationDataSpec {
+  category: string
+  participant: string
+  interface: "RankTrace" | "GTrace" | "Binary"
+}
+
 export interface ContinuousAnnotationTaskSpec extends BaseTaskSpec {
   /**
    * @default "ContinuousAnnotationTask"
@@ -11,9 +17,6 @@ export interface ContinuousAnnotationTaskSpec extends BaseTaskSpec {
     type: "video"
     url: string
   }
-  annotations: {
-    name: string
-    interface: "RankTrace" | "GTrace" | "Binary"
-  }[]
+  annotations: AnnotationDataSpec[]
   userCanAdd: boolean
 }

--- a/covfee/server/tasks/continuous_annotation.py
+++ b/covfee/server/tasks/continuous_annotation.py
@@ -34,8 +34,9 @@ class ContinuousAnnotationTask(BaseCovfeeTask):
             self.session.add(
                 Annotation(
                     task_id=self.task.id,
-                    name=annot["name"],
+                    category=annot["category"],
                     interface=annot["interface"],
+                    participant=annot["participant"],
                 )
             )
 
@@ -80,6 +81,8 @@ def update_annotation(annotid):
     updates = request.json
     for key, value in updates.items():
         if hasattr(annot, key):
+            if key in ["created_at", "updated_at"]:
+                continue
             setattr(annot, key, value)
 
     app.session.commit()
@@ -108,7 +111,8 @@ class Annotation(Base):
     task_id: Mapped[int] = mapped_column(ForeignKey("nodeinstances.id"))
     task: Mapped[TaskInstance] = relationship()
 
-    name: Mapped[str]
+    category: Mapped[str]
+    participant: Mapped[str]
     interface: Mapped[Dict[str, Any]]  # json column
     data_json: Mapped[Optional[Dict[str, Any]]]
 

--- a/samples/continuous_annotation/continous_annotation.py
+++ b/samples/continuous_annotation/continous_annotation.py
@@ -6,7 +6,11 @@ config.load_environment("local")
 
 my_task_1 = tasks.ContinuousAnnotationTaskSpec(
     name="My Task 1",
-    annotations=[{"name": "Arousal", "interface": "RankTrace"}],
+    annotations=[
+        {"category": "Speaking", "interface": "Binary", "participant": "Participant_1"},
+        {"category": "Laughing", "interface": "Binary", "participant": "Participant_1"},
+        {"category": "Jumping", "interface": "Binary", "participant": "Participant_2"},
+    ],
     media={
         "type": "video",
         "url": "https://file-examples.com/storage/fec71f2ebe65d8e339e8b9c/2017/04/file_example_MP4_640_3MG.mp4",


### PR DESCRIPTION
- Implemented the POST/UPDATE functionality for an annotation buffer
- On the update annotation function of the rest api, the updates to "created_at" and "updated_at" are being ignored now, because setting a str type leads to a crash
- Introduced "participant" as part of the specs and annotation data point
- Redefined specs to include a participant entry.
- The UI is now populated by annotations data fetched by the server, instead of being filled up by the specs
- Renamed the annotation.name into annotation.category given that name loses meaning given a annotation is chracterized by its type (eg. Speaking, Laughing, nose, etc.), defined as category, and the participant associated with the annotation.
- The database is now also initialized with participant definition data
- Now the ContinuousAnnotationTask React component is driven solely by the currently selected annotation index, which points to an AnnotationData element, which contains both the annotation category and participant name
- Added safety logic for uninitialized data (not yet fetched), for fetched but not valid, and for a selection index outside of the array length.
- The annotation options are now also populated and defined per participant, as found in the data.