### PR TITLE
Eula update

### DIFF
--- a/covfee/client/input/form.tsx
+++ b/covfee/client/input/form.tsx
@@ -121,6 +121,29 @@ export const Form: React.FC<React.PropsWithChildren<Props>> = (props) => {
     }
   }
 
+  const agreement_signed = () => {
+    if (args.fields) {
+      if (args.values === null || args.values === undefined) {
+        return false
+      }
+      for (const field of args.fields) {
+        if (
+          field.required &&
+          field.name === "agreement_code" &&
+          (args.values[field.name] === null ||
+            args.values[field.name] === undefined ||
+            !args.values[field.name] ||
+            args.values[field.name] !== "06F2w4adS9Zu")
+        ) {
+          return false
+        }
+      }
+      return true
+    } else {
+      return true // if no fields or no fields are required, then the form is always valid
+    }
+  }
+
   const renderInputElement = (
     inputType: string,
     elementProps: any,
@@ -232,7 +255,7 @@ export const Form: React.FC<React.PropsWithChildren<Props>> = (props) => {
       {args.renderSubmitButton && (
         <AntdForm.Item>
           {args.renderSubmitButton({
-            disabled: args.disabled || !required_fields_filled(),
+            disabled: args.disabled || !required_fields_filled() || !agreement_signed(),
           })}
           {/* <Button type="primary" htmlType="submit" disabled={this.props.disabled}>
                   {this.props.submitButtonText}

--- a/samples/continuous_annotation/continuous_annotation.py
+++ b/samples/continuous_annotation/continuous_annotation.py
@@ -10,14 +10,8 @@ spec_consent_form = {
     "form": {
         "fields": [
             {
-                "name": "name",
-                "label": "Full name:",
-                "required": True,
-                "input": {"inputType": "Input"},
-            },
-            {
-                "name": "email",
-                "label": "email:",
+                "name": "agreement_code",
+                "label": "Agreement code:",
                 "required": True,
                 "input": {"inputType": "Input"},
             },

--- a/samples/continuous_annotation/www/consent.html
+++ b/samples/continuous_annotation/www/consent.html
@@ -144,6 +144,9 @@
       Netherlands in relation to data and personality pro- tection with regard
       to the data contained within the Daaset collected and processed by the
       Licensor:
+
+      Download the user agreement and send it to this email <b>SPCLab@tudelft.nl</b> with the text below. After we receive and We will send you a code to access the data.
+      I <YOUR NAME> declare that I have read the attached agreement, that I agree with and that I will comply with its terms.
     </div>
   </body>
 </html>


### PR DESCRIPTION
We have to get the annotators to agree via email. To control that, we will send them a code that will let them access the data. This implementation is suboptimal because the button only gets enabled after the code is correct. We have two options:

- Work more on this so that we show the alert when the button is clicked. I looked into this and it is quite a few code changes because the button creation logic is a few layers below the code that changed.
- Have a separate HIT were we ask the annotators to sign the agreement and only let those access the actual annotation tasks.