### PR TITLE
Set volume to zero when playing the video, fixes #25

### DIFF
--- a/covfee/client/tasks/continuous_annotation/index.tsx
+++ b/covfee/client/tasks/continuous_annotation/index.tsx
@@ -222,6 +222,7 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
   const videoPlayerRef = useRef<VideoJsPlayer>(null)
   const handleVideoPlayerReady = (player: VideoJsPlayer) => {
     videoPlayerRef.current = player
+    videoPlayerRef.current.volume(0)
   }
   useEffect(() => {
     if (videoPlayerRef.current) {


### PR DESCRIPTION
We want to do the annotation without audio. Ideally, this would be a prop of the class but doing it like this for now. Note that we cannot disable picture in picture for firefox https://stackoverflow.com/questions/67125559/how-do-i-remove-picture-in-picture-icon-in-video-js