### PR TITLE
Add prolific_pid and start date to the admin panel

### DIFF
--- a/covfee/client/admin/hit_block/journey_buttons.tsx
+++ b/covfee/client/admin/hit_block/journey_buttons.tsx
@@ -11,10 +11,15 @@ import * as React from "react"
 import { styled } from "styled-components"
 import { chatContext } from "../../chat_context"
 import { fetchAnnotator, useJourneyFns } from "../../models/Journey"
-import { Annotator, JourneyType } from "../../types/journey"
+import { JourneyType } from "../../types/journey"
 import { JourneyStatusToColor, StatusIcon, getJourneyStatus } from "../utils"
 import { ButtonsContainer } from "./utils"
 const { confirm } = Modal
+
+interface Annotator {
+  prolific_id: string
+  created_at: Date
+}
 
 type JourneyRowProps = {
   journey: JourneyType

--- a/covfee/client/admin/hit_block/journey_buttons.tsx
+++ b/covfee/client/admin/hit_block/journey_buttons.tsx
@@ -10,7 +10,7 @@ import classNames from "classnames"
 import * as React from "react"
 import { styled } from "styled-components"
 import { chatContext } from "../../chat_context"
-import { fetch_annotator_data, useJourneyFns } from "../../models/Journey"
+import { fetchAnnotator, useJourneyFns } from "../../models/Journey"
 import { Annotator, JourneyType } from "../../types/journey"
 import { JourneyStatusToColor, StatusIcon, getJourneyStatus } from "../utils"
 import { ButtonsContainer } from "./utils"
@@ -33,7 +33,7 @@ export const JourneyRow = ({
   const [annotator, setAnnotator] = React.useState<Annotator>(null)
 
   React.useEffect(() => {
-    fetch_annotator_data(journey.id).then((payload) => {
+    fetchAnnotator(journey.id).then((payload) => {
       if (
         payload == null ||
         payload.prolific_pid == null ||

--- a/covfee/client/admin/hit_block/journey_buttons.tsx
+++ b/covfee/client/admin/hit_block/journey_buttons.tsx
@@ -35,7 +35,7 @@ export const JourneyRow = ({
   React.useEffect(() => {
     fetchAnnotator(journey.id).then((payload) => {
       if (
-        payload == null ||
+        Object.keys(payload).length === 0 ||
         payload.prolific_pid == null ||
         payload.created_at == null
       ) {

--- a/covfee/client/admin/hit_block/journey_buttons.tsx
+++ b/covfee/client/admin/hit_block/journey_buttons.tsx
@@ -34,11 +34,7 @@ export const JourneyRow = ({
 
   React.useEffect(() => {
     fetchAnnotator(journey.id).then((payload) => {
-      if (
-        Object.keys(payload).length === 0 ||
-        payload.prolific_pid == null ||
-        payload.created_at == null
-      ) {
+      if (Object.keys(payload).length === 0) {
         return
       }
       console.log(

--- a/covfee/client/admin/hit_block/journey_buttons.tsx
+++ b/covfee/client/admin/hit_block/journey_buttons.tsx
@@ -30,9 +30,7 @@ export const JourneyRow = ({
 }: JourneyRowProps) => {
   const { addChats } = React.useContext(chatContext)
   const { getUrl } = useJourneyFns(journey)
-  const [annotator_data, setAnnotatorData] = React.useState<Annotator>(null)
-  const [show_annotator_data, setShowAnnotatorData] =
-    React.useState<boolean>(false)
+  const [annotator, setAnnotator] = React.useState<Annotator>(null)
 
   React.useEffect(() => {
     fetch_annotator_data(journey.id).then((payload) => {
@@ -41,7 +39,6 @@ export const JourneyRow = ({
         payload.prolific_pid == null ||
         payload.created_at == null
       ) {
-        setShowAnnotatorData(false)
         return
       }
       console.log(
@@ -49,11 +46,10 @@ export const JourneyRow = ({
       )
       var date = new Date(payload.created_at)
       date.setMilliseconds(0) // Ignore milliseconds
-      setAnnotatorData({
+      setAnnotator({
         prolific_id: payload.prolific_pid,
         created_at: date,
       } as Annotator)
-      setShowAnnotatorData(true)
     })
   }, [journey])
 
@@ -83,10 +79,10 @@ export const JourneyRow = ({
         <span> </span>
         <span>{journey.id.substring(0, 10)} </span> <LinkOutlined />
       </a>
-      {show_annotator_data && (
+      {annotator != null && (
         <ul>
-          <li>Prolific PID: &quot;{annotator_data.prolific_id}&quot;</li>
-          <li>Start date: {annotator_data.created_at.toLocaleString()}</li>
+          <li>Prolific PID: &quot;{annotator.prolific_id}&quot;</li>
+          <li>Start date: {annotator.created_at.toLocaleString()}</li>
         </ul>
       )}
       <ButtonsContainer>

--- a/covfee/client/models/Journey.ts
+++ b/covfee/client/models/Journey.ts
@@ -86,7 +86,7 @@ export const submitJourney = (id: string) => {
   return fetcher(url, requestOptions).then(throwBadResponse)
 }
 
-export const fetch_annotator_data = (id: string) => {
-  const url = Constants.api_url + "/journeys/" + id + "/annotator_data"
+export const fetchAnnotator = (id: string) => {
+  const url = Constants.api_url + "/journeys/" + id + "/annotator"
   return fetcher(url).then(throwBadResponse)
 }

--- a/covfee/client/models/Journey.ts
+++ b/covfee/client/models/Journey.ts
@@ -1,14 +1,14 @@
 import * as React from "react"
 
-import { JourneyType as FullJourney } from "../types/journey"
-import { JourneyType as ReducedJourney } from "../types/hit"
-import { myerror, fetcher, myinfo, throwBadResponse } from "../utils"
-import download from "downloadjs"
 import Constants from "Constants"
+import download from "downloadjs"
+import { JourneyType as ReducedJourney } from "../types/hit"
+import { JourneyType as FullJourney } from "../types/journey"
+import { fetcher, myerror, myinfo, throwBadResponse } from "../utils"
 
 type JourneyType = FullJourney | ReducedJourney
 
-export type { JourneyType, FullJourney, ReducedJourney }
+export type { FullJourney, JourneyType, ReducedJourney }
 
 export const useJourneyFns = <T extends JourneyType>(journey: T) => {
   const getApiUrl = () => {
@@ -84,4 +84,9 @@ export const submitJourney = (id: string) => {
     body: JSON.stringify({ success: true }),
   }
   return fetcher(url, requestOptions).then(throwBadResponse)
+}
+
+export const fetch_annotator_data = (id: string) => {
+  const url = Constants.api_url + "/journeys/" + id + "/annotator_data"
+  return fetcher(url).then(throwBadResponse)
 }

--- a/covfee/client/types/journey.ts
+++ b/covfee/client/types/journey.ts
@@ -27,5 +27,5 @@ export interface JourneyType extends Omit<JourneySpec, "nodes"> {
   num_connections: number
   curr_node_id: number
   status: JourneyApiStatus
-  annotator?: Annotator
+  annotator?: Annotator | null
 }

--- a/covfee/client/types/journey.ts
+++ b/covfee/client/types/journey.ts
@@ -1,6 +1,11 @@
 import { JourneySpec } from "@covfee-spec/journey"
-import { NodeType } from "./node"
 import { MarkdownContentSpec } from "@covfee-spec/tasks/utils"
+import { NodeType } from "./node"
+
+export interface Annotator {
+  prolific_id: string
+  created_at: Date
+}
 
 export const JourneyApiStatuses = [
   "INIT",
@@ -22,4 +27,5 @@ export interface JourneyType extends Omit<JourneySpec, "nodes"> {
   num_connections: number
   curr_node_id: number
   status: JourneyApiStatus
+  annotator?: Annotator
 }

--- a/covfee/client/types/journey.ts
+++ b/covfee/client/types/journey.ts
@@ -2,11 +2,6 @@ import { JourneySpec } from "@covfee-spec/journey"
 import { MarkdownContentSpec } from "@covfee-spec/tasks/utils"
 import { NodeType } from "./node"
 
-export interface Annotator {
-  prolific_id: string
-  created_at: Date
-}
-
 export const JourneyApiStatuses = [
   "INIT",
   "RUNNING",
@@ -27,5 +22,4 @@ export interface JourneyType extends Omit<JourneySpec, "nodes"> {
   num_connections: number
   curr_node_id: number
   status: JourneyApiStatus
-  annotator?: Annotator | null
 }

--- a/covfee/server/rest_api/journeys.py
+++ b/covfee/server/rest_api/journeys.py
@@ -82,10 +82,10 @@ def node_ready(jid, nidx, value):
 
     return "", 200
 
-# Return the annotator_data for the annotator working on this journey
-@api.route("/journeys/<jid>/annotator_data")
+# Return the annotator data for the annotator working on this journey
+@api.route("/journeys/<jid>/annotator")
 @admin_required
-def annotator_data(jid):
+def annotator(jid):
     res :JourneyInstance  = app.session.query(JourneyInstance).get(bytes.fromhex(jid))
     if res.annotator is None:
         return {}

--- a/covfee/server/rest_api/journeys.py
+++ b/covfee/server/rest_api/journeys.py
@@ -81,3 +81,12 @@ def node_ready(jid, nidx, value):
     socketio.emit("status", payload, namespace="/admin")
 
     return "", 200
+
+# Return the annotator_data for the annotator working on this journey
+@api.route("/journeys/<jid>/annotator_data")
+@admin_required
+def annotator_data(jid):
+    res :JourneyInstance  = app.session.query(JourneyInstance).get(bytes.fromhex(jid))
+    if res.annotator is None:
+        return {}
+    return {"prolific_pid": res.annotator.prolific_id, "created_at": str(res.annotator.created_at)}


### PR DESCRIPTION
Add the prolific PID and start date to the admin panel. This is added to the journeys like so:
![Screenshot from 2024-04-05 15-47-22](https://github.com/TUDelft-SPC-Lab/covfee/assets/1507774/f3b35029-ebfb-402c-8b4a-ad8408833054)
