### PR TITLE
.#29 Added numeric progress to nodes visible on admin panel

### DIFF
--- a/covfee/client/admin/force_graph.tsx
+++ b/covfee/client/admin/force_graph.tsx
@@ -1,10 +1,10 @@
-import * as React from "react"
+import type { SimulationNodeDatum } from "d3"
 import * as d3 from "d3"
-import type { SimulationNodeDatum, Simulation } from "d3"
-import { NodeStatusToColor, getNodeStatus } from "./utils"
-import { NodeType } from "../types/node"
+import * as React from "react"
+import { ReducedJourney } from "../models/Journey"
 import { HitInstanceType } from "../types/hit"
-import { JourneyType, ReducedJourney } from "../models/Journey"
+import { NodeType } from "../types/node"
+import { NodeStatusToColor, getNodeStatus } from "./utils"
 
 const getDimensions = (nodes: SimulationNode[], nodeRadius: number) => {
   let minX = Infinity,
@@ -124,6 +124,9 @@ export const ForceGraph = ({
       .attr("stroke-opacity", ({ index }) =>
         nodes[index].focused ? "0.1" : "0.01"
       )
+    nodesRefs.current
+      .selectChildren("text")
+      .text(({ index }) => nodes[index].name)
   }
 
   React.useEffect(() => {
@@ -262,6 +265,7 @@ export const ForceGraph = ({
         .attr("fill", "#000")
         .attr("stroke", "#fff")
         .attr("stroke-width", "5px")
+        .attr("text-anchor", "middle")
         .attr("x", (d) => d.x)
         .attr("y", (d) => d.y)
         .text(({ index }) => nodes[index].name)

--- a/covfee/client/admin/force_graph.tsx
+++ b/covfee/client/admin/force_graph.tsx
@@ -25,7 +25,7 @@ const createNodes = (nodes: NodeType[], focusedNode: number) => {
   const res = nodes.map((n, index) => {
     let name = n.name
     if (n.progress !== null && n.progress !== undefined) {
-      name += ` (${n.progress}%)`
+      name += ` (${n.progress.toFixed(1)}%)`
     }
     return {
       id: n.id,

--- a/covfee/client/admin/force_graph.tsx
+++ b/covfee/client/admin/force_graph.tsx
@@ -22,12 +22,18 @@ const getDimensions = (nodes: SimulationNode[], nodeRadius: number) => {
 }
 
 const createNodes = (nodes: NodeType[], focusedNode: number) => {
-  const res = nodes.map((n, index) => ({
-    id: n.id,
-    name: n.name,
-    focused: focusedNode == index,
-    color: NodeStatusToColor[getNodeStatus(n)],
-  }))
+  const res = nodes.map((n, index) => {
+    let name = n.name
+    if (n.progress !== null && n.progress !== undefined) {
+      name += ` (${n.progress}%)`
+    }
+    return {
+      id: n.id,
+      name: name,
+      focused: focusedNode === index,
+      color: NodeStatusToColor[getNodeStatus(n)],
+    }
+  })
 
   return res
 }

--- a/covfee/client/admin/hit_block/node_buttons.tsx
+++ b/covfee/client/admin/hit_block/node_buttons.tsx
@@ -1,23 +1,22 @@
 import * as React from "react"
 import styled from "styled-components"
 
-import { ManualStatuses, NodeType } from "../../types/node"
-import { Modal } from "antd"
-const { confirm } = Modal
 import {
-  LinkOutlined,
+  EyeOutlined,
   PauseCircleOutlined,
   PlayCircleOutlined,
   RedoOutlined,
   WechatOutlined,
-  EyeOutlined,
 } from "@ant-design/icons"
-import { useNodeFns } from "../../models/Node"
-import { NodeStatusToColor, StatusIcon, getNodeStatus } from "../utils"
+import { Modal } from "antd"
 import classNames from "classnames"
 import { chatContext } from "../../chat_context"
-import { ButtonsContainer, Row } from "./utils"
+import { useNodeFns } from "../../models/Node"
+import { NodeType } from "../../types/node"
 import { adminContext } from "../admin_context"
+import { NodeStatusToColor, StatusIcon, getNodeStatus } from "../utils"
+import { ButtonsContainer, Row } from "./utils"
+const { confirm } = Modal
 
 type NodeRowProps = {
   node: NodeType
@@ -46,7 +45,9 @@ export const NodeRow = ({
           <StatusIcon color={NodeStatusToColor[getNodeStatus(node)]} />
         </span>
         {node.name}[{node.id}] - {node.status}
-        {node.progress ? "(" + node.progress + "%)" : ""}
+        {typeof node.progress === "number"
+          ? "(" + node.progress.toFixed(1) + "%)"
+          : ""}
       </a>
       <NodeButtons node={node} />
     </Row>

--- a/covfee/client/admin/hit_block/node_buttons.tsx
+++ b/covfee/client/admin/hit_block/node_buttons.tsx
@@ -46,6 +46,7 @@ export const NodeRow = ({
           <StatusIcon color={NodeStatusToColor[getNodeStatus(node)]} />
         </span>
         {node.name}[{node.id}] - {node.status}
+        {node.progress ? "(" + node.progress + "%)" : ""}
       </a>
       <NodeButtons node={node} />
     </Row>

--- a/covfee/client/admin/node_overlay.tsx
+++ b/covfee/client/admin/node_overlay.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import { styled } from "styled-components"
 import { NodeLoader } from "../journey/node_loader"
-import { NodeType } from "../types/node"
 import { fetchNode } from "../models/Node"
+import { NodeType } from "../types/node"
 import { adminContext } from "./admin_context"
 
 export const NodeOverlay: React.FC<React.PropsWithChildren<{}>> = () => {

--- a/covfee/client/app_context.tsx
+++ b/covfee/client/app_context.tsx
@@ -63,6 +63,7 @@ export interface ServerToClientEvents {
     dt_count: string
     dt_finish: string
     t_elapsed: number
+    progress: number | null
   }) => void
 
   // for tasks with shared state

--- a/covfee/client/app_context.tsx
+++ b/covfee/client/app_context.tsx
@@ -1,7 +1,11 @@
+import { Action } from "@reduxjs/toolkit"
 import * as React from "react"
-import { io, Socket } from "socket.io-client"
+import { Socket } from "socket.io-client"
+import {
+  Action as ActionResponse,
+  State as StateResponse,
+} from "../server/socketio/types"
 import { UserContextMethods, UserState } from "./app_provider"
-import { UseChats } from "models/Chat"
 import { Chat, ChatMessage } from "./types/chat"
 import {
   JourneyAssoc,
@@ -9,14 +13,7 @@ import {
   NodeStatus,
   TaskResponseType,
 } from "./types/node"
-import {
-  State as StateResponse,
-  Action as ActionResponse,
-  ActionRequestPayload,
-  StateRequestPayload,
-} from "../server/socketio/types"
 import { UserConfig } from "./user_config"
-import { Action } from "@reduxjs/toolkit"
 
 export interface ServerToClientEvents {
   /**

--- a/covfee/client/journey/node_loader.tsx
+++ b/covfee/client/journey/node_loader.tsx
@@ -59,6 +59,8 @@ export const NodeLoader: React.FC<Props> = (props: Props) => {
     fetchResponse,
     submitResponse,
     setReady,
+    setProgress: setNodeProgress,
+    submitProgress,
   } = useNode(args.node, socket)
 
   const [isLoading, setIsLoading] = React.useState(true)
@@ -297,6 +299,17 @@ export const NodeLoader: React.FC<Props> = (props: Props) => {
       })
   }
 
+  const handleTaskProgressSubmit = (progress: number) => {
+    submitProgress(progress)
+      .then((data: any) => {
+        setNodeProgress(progress)
+      })
+      .catch((error) => {
+        myerror("Error updating task progress.", error)
+        setNodeProgress(progress)
+      })
+  }
+
   const renderErrorMessage = React.useCallback(() => {
     return (
       <MessageContainer>
@@ -441,6 +454,7 @@ export const NodeLoader: React.FC<Props> = (props: Props) => {
                 disabled: node.status == "FINISHED",
                 onSubmit: handleTaskSubmit,
                 renderSubmitButton: renderTaskSubmitButton,
+                onUpdateProgress: handleTaskProgressSubmit,
               }
 
               const taskElement = React.createElement(

--- a/covfee/client/models/Hits.ts
+++ b/covfee/client/models/Hits.ts
@@ -1,10 +1,10 @@
-import React, { useState } from "react"
-import { HitInstanceType } from "../types/hit"
-import { fetcher, throwBadResponse } from "../utils"
 import Constants from "Constants"
+import React, { useState } from "react"
 import { MainSocket, ServerToClientEvents } from "../app_context"
-import { JourneyType } from "./Journey"
+import { HitInstanceType } from "../types/hit"
 import { NodeType } from "../types/node"
+import { fetcher, throwBadResponse } from "../utils"
+import { JourneyType } from "./Journey"
 
 export const useHitInstances = (
   data: HitInstanceType[],
@@ -85,7 +85,7 @@ export const useHitInstances = (
         dt_count: data.dt_count,
         dt_finish: data.dt_finish,
         t_elapsed: data.t_elapsed,
-        progress: data.progress,
+        progress: data.progress !== null ? +data.progress : null,
       })
     }
 

--- a/covfee/client/models/Hits.ts
+++ b/covfee/client/models/Hits.ts
@@ -85,6 +85,7 @@ export const useHitInstances = (
         dt_count: data.dt_count,
         dt_finish: data.dt_finish,
         t_elapsed: data.t_elapsed,
+        progress: data.progress,
       })
     }
 

--- a/covfee/client/models/Node.ts
+++ b/covfee/client/models/Node.ts
@@ -1,4 +1,6 @@
-import React, { useState, useCallback, useEffect } from "react"
+import Constants from "Constants"
+import React, { useCallback, useEffect, useState } from "react"
+import { MainSocket, ServerToClientEvents } from "../app_context"
 import {
   ManualStatus,
   ManualStatuses,
@@ -7,8 +9,6 @@ import {
   TaskResponseType,
 } from "../types/node"
 import { fetcher, throwBadResponse } from "../utils"
-import { MainSocket, ServerToClientEvents } from "../app_context"
-import Constants from "Constants"
 
 export function useNodeFns(node: NodeType) {
   const fetchResponse = useCallback(() => {
@@ -177,7 +177,7 @@ export function useNode(data: NodeType, socket: MainSocket = null) {
         dt_count: data.dt_count,
         dt_finish: data.dt_finish,
         t_elapsed: data.t_elapsed,
-        progress: data.progress,
+        progress: data.progress !== null ? +data.progress : null,
       }))
     }
 

--- a/covfee/client/models/Node.ts
+++ b/covfee/client/models/Node.ts
@@ -30,6 +30,15 @@ export function useNodeFns(node: NodeType) {
     [node.url]
   )
 
+  const submitProgress = useCallback(
+    (progress: number) => {
+      const url = node.url + "/progress/" + progress
+
+      return fetcher(url).then(throwBadResponse)
+    },
+    [node.url]
+  )
+
   const restart = useCallback(() => {
     const url = node.url + "/restart"
 
@@ -91,6 +100,7 @@ export function useNodeFns(node: NodeType) {
     setManualStatus,
     restart,
     setReady,
+    submitProgress,
   }
 }
 
@@ -115,6 +125,7 @@ export function useNode(data: NodeType, socket: MainSocket = null) {
     makeResponse,
     submitResponse: submitResponseFn,
     setReady,
+    submitProgress,
   } = useNodeFns(node)
 
   const numOnlineJourneys: number = React.useMemo(() => {
@@ -129,6 +140,13 @@ export function useNode(data: NodeType, socket: MainSocket = null) {
     setNode((node) => ({
       ...node,
       status: status,
+    }))
+  }
+
+  const setProgress = (progress: number) => {
+    setNode((node) => ({
+      ...node,
+      progress: progress,
     }))
   }
 
@@ -159,6 +177,7 @@ export function useNode(data: NodeType, socket: MainSocket = null) {
         dt_count: data.dt_count,
         dt_finish: data.dt_finish,
         t_elapsed: data.t_elapsed,
+        progress: data.progress,
       }))
     }
 
@@ -190,10 +209,12 @@ export function useNode(data: NodeType, socket: MainSocket = null) {
     response,
     setResponse,
     setStatus,
+    setProgress,
     fetchResponse,
     submitResponse,
     makeResponse,
     setReady,
+    submitProgress,
   }
 }
 

--- a/covfee/client/tasks/base.ts
+++ b/covfee/client/tasks/base.ts
@@ -52,6 +52,12 @@ export interface BaseTaskProps {
    * Returns a submit button to be rendered in the task. Alternative to directly calling onSubmit.
    */
   renderSubmitButton: (arg0?: any) => React.ReactNode
+
+  /**
+   * To be called when wanting to update the task's numeric progress (value between 0 and 100),
+   * making the information propagate into the admin interface.
+   */
+  onUpdateProgress: (progress: number) => void
 }
 
 export interface CovfeeTaskProps<T> extends BaseTaskProps {

--- a/covfee/client/tasks/continuous_annotation/continous_annotation.module.css
+++ b/covfee/client/tasks/continuous_annotation/continous_annotation.module.css
@@ -124,7 +124,7 @@
 }
 
 .action-task-progress-bar {
-  width: 100%;
+  width: 95%;
 }
 
 .action-task-progress-text {

--- a/covfee/client/tasks/continuous_annotation/index.tsx
+++ b/covfee/client/tasks/continuous_annotation/index.tsx
@@ -110,9 +110,8 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
     numberOfAnnotationsCompleted = annotationsDataMirror.filter(
       (annotationData: AnnotationData) => annotationData.data_json !== null
     ).length
-    taskCompletionPercentage = Math.round(
+    taskCompletionPercentage =
       (100 * numberOfAnnotationsCompleted) / numberOfAnnotations
-    )
   }
   const [isMarkParticipantModalOpen, setIsMarkParticipantModalOpen] =
     useState(false)
@@ -716,6 +715,7 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
             <Progress
               percent={taskCompletionPercentage}
               className={styles["action-task-progress-bar"]}
+              format={(percent) => percent.toFixed(1) + "%"}
             />
             {isEntireTaskCompleted && (
               <>

--- a/covfee/client/tasks/continuous_annotation/index.tsx
+++ b/covfee/client/tasks/continuous_annotation/index.tsx
@@ -101,6 +101,7 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
   var isEntireTaskCompleted = false
   var numberOfAnnotationsCompleted = 0
   var numberOfAnnotations = 0
+  var taskCompletionPercentage = 0
   if (annotationsDataMirror !== undefined) {
     isEntireTaskCompleted = annotationsDataMirror.every(
       (annotationData: AnnotationData) => annotationData.data_json !== null
@@ -109,6 +110,9 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
     numberOfAnnotationsCompleted = annotationsDataMirror.filter(
       (annotationData: AnnotationData) => annotationData.data_json !== null
     ).length
+    taskCompletionPercentage = Math.round(
+      (100 * numberOfAnnotationsCompleted) / numberOfAnnotations
+    )
   }
   const [isMarkParticipantModalOpen, setIsMarkParticipantModalOpen] =
     useState(false)
@@ -166,6 +170,7 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
       ...annotationsDataMirror[selectedAnnotationIndex],
       data_json: activeAnnotationDataArray.buffer,
     }
+
     try {
       const url =
         Constants.base_url +
@@ -212,6 +217,10 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
       dispatch(actions.setSelectedAnnotationIndex(0))
     }
   }, [selectedAnnotationIndex, annotationsDataMirror])
+
+  useEffect(() => {
+    props.onUpdateProgress(taskCompletionPercentage)
+  }, [annotationsDataMirror])
 
   //*************************************************************//
   //----------- Video playback fuctionality -------------------- //
@@ -705,9 +714,7 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
               Task progress
             </h3>
             <Progress
-              percent={Math.round(
-                (100 * numberOfAnnotationsCompleted) / numberOfAnnotations
-              )}
+              percent={taskCompletionPercentage}
               className={styles["action-task-progress-bar"]}
             />
             {isEntireTaskCompleted && (

--- a/covfee/client/types/node.ts
+++ b/covfee/client/types/node.ts
@@ -45,6 +45,7 @@ export interface NodeType extends AllPropsRequired<BaseNodeSpec> {
    * Status of the node
    */
   status: NodeStatus
+  progress?: number | null
   manual: ManualStatus
   taskData: any
   journeys: JourneyAssoc[]

--- a/covfee/client/types/node.ts
+++ b/covfee/client/types/node.ts
@@ -45,7 +45,7 @@ export interface NodeType extends AllPropsRequired<BaseNodeSpec> {
    * Status of the node
    */
   status: NodeStatus
-  progress?: number | null
+  progress: number | null
   manual: ManualStatus
   taskData: any
   journeys: JourneyAssoc[]

--- a/covfee/server/orm/node.py
+++ b/covfee/server/orm/node.py
@@ -179,6 +179,9 @@ class NodeInstance(Base):
     )
     status: Mapped[NodeInstanceStatus] = mapped_column(default=NodeInstanceStatus.INIT)
 
+    # Optional numeric [0-100] progress for the Node
+    progress: Mapped[Optional[float]] = mapped_column(default=None)
+
     dt_start: Mapped[Optional[datetime]]
     dt_pause: Mapped[Optional[datetime]]
     dt_count: Mapped[Optional[datetime]]

--- a/covfee/server/orm/task.py
+++ b/covfee/server/orm/task.py
@@ -121,6 +121,7 @@ class TaskInstance(NodeInstance):
             "dt_count": utils.datetime_to_str(self.dt_count),
             "dt_pause": utils.datetime_to_str(self.dt_pause),
             "t_elapsed": self.t_elapsed,
+            "progress": self.progress,
         }
 
     def pause(self, pause: bool):

--- a/covfee/server/rest_api/nodes.py
+++ b/covfee/server/rest_api/nodes.py
@@ -67,6 +67,20 @@ def response_submit(nid):
     return jsonify(res)
 
 
+@api.route("/nodes/<nid>/progress/<progress>")
+def set_progress(nid, progress: float):
+    node: NodeInstance = app.session.query(NodeInstance).get(int(nid))
+    node.progress = progress
+
+    if isinstance(node, TaskInstance):
+        payload = node.make_status_payload()
+        socketio.emit("status", payload, to=node.id)
+        socketio.emit("status", payload, namespace="/admin")
+
+    app.session.commit()
+    return "", 200
+
+
 # state management
 @api.route("/nodes/<nid>/manual/<status>")
 @admin_required
@@ -97,5 +111,4 @@ def restart_node(nid):
         socketio.emit("status", payload, namespace="/admin")
 
     app.session.commit()
-    return "", 200
     return "", 200


### PR DESCRIPTION
- The Node ORM class was extended to include a progress column
- The Node REST API was extended so that the client make a request to update the ongoing progress for the Node
- The Admin dashboard was modified to display the ongoing progress if available.
- Displaying the node progress on the graph in the admin panel