### PR TITLE
#33 Added id_within_study to hitspecs and journey specs

### DIFF
--- a/covfee/server/orm/hit.py
+++ b/covfee/server/orm/hit.py
@@ -6,7 +6,7 @@ import hmac
 import binascii
 import hashlib
 import datetime
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, Optional
 from hashlib import sha256
 from pprint import pformat
 
@@ -27,6 +27,12 @@ class HITSpec(Base):
     __table_args__ = (UniqueConstraint("project_id", "name"),)
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str]
+
+    # An optional id that the study administrator can attach to this HIT
+    # making it identifiable through multiple launches of "covfee make"
+    # and thus being able to add more hits/journeys without destroying
+    # the database. It's a string as it is intended to be human-readable
+    id_within_study: Mapped[Optional[str]] = mapped_column(unique=True)
 
     project_id: Mapped[int] = mapped_column(ForeignKey("projects.id"))
     # project_id = Column(Integer, ForeignKey("projects.name"))
@@ -105,7 +111,8 @@ class HITSpec(Base):
 
 
 class HITInstance(Base):
-    """Represents an instance of a HIT, to be solved by one user
+    """Represents an instance of a HIT, to be solved by one or multiple users through their
+    respective journeys
     - one HIT instance maps to one URL that can be sent to a participant to access and solve the HIT.
     - a HIT instance is specified by the abstract HIT it is an instance of.
     - a HIT instance is linked to a list of tasks (instantiated task specifications),

--- a/covfee/server/orm/journey.py
+++ b/covfee/server/orm/journey.py
@@ -30,6 +30,12 @@ class JourneySpec(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[Optional[str]]
 
+    # An optional id that the study administrator can attach to this Journey
+    # making it identifiable through multiple launches of "covfee make"
+    # and thus being able to add more hits/journeys without destroying
+    # the database. It's a string as it is intended to be human-readable
+    id_within_study: Mapped[Optional[str]] = mapped_column(unique=True)
+
     # spec relationships
     # up
     hitspec_id: Mapped[int] = mapped_column(ForeignKey("hitspecs.id"))
@@ -86,7 +92,12 @@ class JourneyInstanceStatus(enum.Enum):
 
 
 class JourneyInstance(Base):
-    """Represents an instance of a HIT, to be solved by one user"""
+    """Represents an instance of a journey, to be solved by one user
+    - one Journey instance maps to one URL that can be sent to a participant to access and solve the HIT.
+    - a Journey instance is specified by the abstract JourneySpec it is an instance of.
+    - a Journey instance is linked to a list of tasks (instantiated task specifications),
+    which hold the responses for the Journey
+    """
 
     __tablename__ = "journeyinstances"
 


### PR DESCRIPTION

This is the PART 1 of the effort to allow study datasets to be persistent while more hits/journeys are added. So studies can be conducted in batches, or other tasks can be added.