### PR TITLE
#23 #22 improve ux for the continuous annotation task for clarity

### DIFF
--- a/covfee/client/tasks/continuous_annotation/action_annotation_flashscreen.tsx
+++ b/covfee/client/tasks/continuous_annotation/action_annotation_flashscreen.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { REGISTER_ACTION_ANNOTATION_KEY } from "./constants"
+import styles from "./continous_annotation.module.css"
+
+type Props = {
+  active: boolean
+  annotation_category: string
+}
+
+const ActionAnnotationFlashscreen: React.FC<Props> = (props) => {
+  return (
+    <div
+      className={`${styles["action-annotation-flashscreen"]} ${
+        props.active
+          ? styles["action-annotation-flashscreen-active-key-pressed"]
+          : styles["action-annotation-flashscreen-active-key-not-pressed"]
+      }`}
+    >
+      <h1>
+        {props.active ? "" : "NOT"} {props.annotation_category}
+      </h1>
+      <h1>{" (Key: " + REGISTER_ACTION_ANNOTATION_KEY + ")"}</h1>
+    </div>
+  )
+}
+
+export default ActionAnnotationFlashscreen

--- a/covfee/client/tasks/continuous_annotation/conflab_participant_selection.tsx
+++ b/covfee/client/tasks/continuous_annotation/conflab_participant_selection.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useRef } from "react"
+// You can download this image and place it in the art folder from:
+// @covfee.ewi.tudelft.nl:/home/kfunesmora/conflab-media/
+// Do not commit to the repo for confidentiality reasons.
+
+// You can download this image and place it in the art folder from:
+// @covfee.ewi.tudelft.nl:/home/kfunesmora/conflab-media/
+// Do not commit to the repo for confidentiality reasons.
+import ConflabGallery from "../../art/conflab-gallery.svg"
+// Hardcoding the size of the viewport of the original svg, which couldn't find
+// a way to retrieve by code.
+const CONFLAB_SVG_ORIGINAL_SIZE = { width: 1427.578, height: 1496.532 }
+const grid_size_x = 6
+const grid_size_y = 8
+
+import styles from "./continous_annotation.module.css"
+
+type ParticipantImageProps = {
+  participant: string
+}
+
+const SelectedParticipantImage: React.FC<ParticipantImageProps> = (props) => {
+  const computeViewBoxOnGalleryToCropSelectedParticipant = () => {
+    const gallerySVGCellWidth = CONFLAB_SVG_ORIGINAL_SIZE.width / grid_size_x
+    const gallerySVGCellHeight = CONFLAB_SVG_ORIGINAL_SIZE.height / grid_size_y
+
+    const participant_id = parseInt(props.participant.split("_")[1])
+    const cell_id =
+      participant_id <= 37 ? participant_id - 1 : participant_id - 3
+    const cell_x = cell_id % grid_size_x
+    const cell_y = Math.floor(cell_id / grid_size_x)
+    const gallerySVGCellX = cell_x * gallerySVGCellWidth
+    const gallerySVGCellY = cell_y * gallerySVGCellHeight
+
+    return `${gallerySVGCellX} ${gallerySVGCellY} ${gallerySVGCellWidth} ${gallerySVGCellHeight}`
+  }
+
+  return (
+    <svg
+      viewBox={computeViewBoxOnGalleryToCropSelectedParticipant()}
+      width="100%"
+      className={styles["selected-participant-svg"]}
+    >
+      <ConflabGallery />
+    </svg>
+  )
+}
+
+type ParticipantGalleryProps = {
+  open: boolean
+  onCancel: () => void
+  onParticipantSelected: (participant: string) => void
+}
+
+const ModalParticipantSelectionGallery: React.FC<ParticipantGalleryProps> = (
+  props
+) => {
+  /***
+  This Component implements a modal overlay of participants which is
+  clickable to select a participant. It is used in the continuous annotation
+  */
+
+  // We use a Ref to know to which DOM element to redirect the keyboard focus
+  // and as to capture key press events. Also, to retrieve the geometry of the
+  // underlying gallery svg image.
+  const galleryOverlayRef = useRef(null)
+  useEffect(() => {
+    if (props.open && galleryOverlayRef.current) {
+      galleryOverlayRef.current.focus()
+    }
+  }, [props.open])
+
+  const handleClickOnGalleryImage = (e: MouseEvent) => {
+    // Based on the known gallery image of participants, we calculate in which
+    // participant the click is falling in.
+    if (galleryOverlayRef.current) {
+      const galleryOverlayImageElement =
+        galleryOverlayRef.current.querySelectorAll("svg")[0]
+      if (galleryOverlayImageElement) {
+        var imageRect = galleryOverlayImageElement.getBoundingClientRect()
+        var cell_x = Math.floor(
+          (grid_size_x * (e.clientX - imageRect.left)) / imageRect.width
+        )
+        var cell_y = Math.floor(
+          (grid_size_y * (e.clientY - imageRect.top)) / imageRect.height
+        )
+        let participant_id: number = cell_y * grid_size_x + cell_x + 1
+        if (participant_id >= 38) {
+          participant_id += 2
+        }
+        props.onParticipantSelected("Participant_" + participant_id)
+      }
+    }
+  }
+
+  if (props.open) {
+    return (
+      <div
+        className={styles["gallery-overlay"]}
+        onKeyDown={(e) => {
+          e.preventDefault()
+          if (e.key === "Escape") {
+            props.onCancel()
+          }
+        }}
+        tabIndex={-1}
+        ref={galleryOverlayRef}
+      >
+        <h1 className={styles["disabled-instructions-text"]}>
+          Click on the participant to select or Press ESC to close
+        </h1>
+        <ConflabGallery
+          className={styles["gallery-overlay-image"]}
+          onClick={handleClickOnGalleryImage}
+        />
+      </div>
+    )
+  } else {
+    return null
+  }
+}
+
+export { ModalParticipantSelectionGallery, SelectedParticipantImage }

--- a/covfee/client/tasks/continuous_annotation/constants.tsx
+++ b/covfee/client/tasks/continuous_annotation/constants.tsx
@@ -1,0 +1,6 @@
+// Keyboard keys we are listening to
+export const REGISTER_ACTION_ANNOTATION_KEY: string = "S"
+export const ABORT_ONGOING_ANNOTATION_KEY: string = "Escape"
+export const CHANGE_VIEW_PREV_KEY: string = "O"
+export const CHANGE_VIEW_NEXT_KEY: string = "L"
+export const TIP_EMOJI: string = "ℹ️"

--- a/covfee/client/tasks/continuous_annotation/continous_annotation.module.css
+++ b/covfee/client/tasks/continuous_annotation/continous_annotation.module.css
@@ -1,5 +1,6 @@
 .action-annotation-task {
   display: flex;
+  justify-content: flex-end;
   height: 100%;
 }
 
@@ -38,6 +39,11 @@
 .left-sidebar {
   min-width: 300px; /* Set a minimum width */
   width: 22%;
+  transition: margin 0.3s ease;
+}
+
+.left-sidebar-hidden {
+  margin-left: -22%;
 }
 
 .sidebar-block {
@@ -69,8 +75,9 @@
   padding: 12px;
   display: flex;
   flex-direction: column;
-  width: 20%;
+  width: 12%;
   min-width: 200px; /* Set a minimum width */
+  align-self: flex-end;
 }
 
 .sidebarBottom {
@@ -85,8 +92,21 @@
 }
 
 .main-content {
-  padding-top: 22px;
+  display: flex;
+  justify-content: flex-end;
   flex: 1;
+  flex-direction: row;
+}
+
+.main-content-video-and-guide {
+  padding-top: 22px;
+  flex-grow: 1;
+  max-width: 85vw;
+  max-height: "50px";
+}
+
+.main-content video-js {
+  height: 100px;
 }
 
 .action-task-dropdown-title {
@@ -150,24 +170,34 @@
 }
 
 .action-annotation-flashscreen {
-  margin: 15px;
   display: flex;
   justify-content: center; /* Horizontally center the content */
   align-items: center; /* Vertically center the content */
   border: 1px solid black;
   border-radius: 6px;
-  height: 100px;
-  background-color: lightgray;
+  height: 10vh;
+  width: 100%;
+  flex-direction: column;
 }
 
-.keyboard-action-register-instruction-text {
-  text-align: center;
-  font-weight: bold;
+.instructions-box-overlay {
+  display: flex;
+  background: rgba(49, 49, 49, 0.8);
+  justify-content: center;
+  flex-direction: column;
+  width: 40%;
+  color: white;
+  position: relative;
+  left: 2%;
+  top: -22vh;
+  height: 20vh;
+  padding-left: 3%;
+  padding-right: 3%;
 }
 
 .action-annotation-flashscreen h1 {
-  font-size: 24px;
-  text-align: center;
+  font-size: 20px;
+  margin: 0px;
 }
 
 .action-annotation-flashscreen-active-key-pressed {

--- a/covfee/client/tasks/continuous_annotation/instructions_sidebar.tsx
+++ b/covfee/client/tasks/continuous_annotation/instructions_sidebar.tsx
@@ -1,0 +1,227 @@
+import type { MenuProps } from "antd"
+import { Button, Dropdown, MenuInfo, Space } from "antd"
+import React from "react"
+import { SelectedParticipantImage } from "./conflab_participant_selection"
+
+import {
+  BorderOutlined,
+  CheckSquareTwoTone,
+  DownOutlined,
+  ExclamationCircleOutlined,
+} from "@ant-design/icons"
+
+import {
+  CHANGE_VIEW_NEXT_KEY,
+  CHANGE_VIEW_PREV_KEY,
+  REGISTER_ACTION_ANNOTATION_KEY,
+  TIP_EMOJI,
+} from "./constants"
+
+import styles from "./continous_annotation.module.css"
+
+type ParticipantOption = {
+  name: string
+  completed: boolean
+}
+
+type AnnotationOption = {
+  category: string
+  index?: number
+  completed: boolean
+}
+
+type Props = {
+  selected_participant: ParticipantOption
+  selected_annotation: AnnotationOption
+  participant_options: ParticipantOption[]
+  annotation_options: AnnotationOption[]
+
+  onCantFindParticipantClick: () => void
+  onParticipantSelected: (participant: string) => void
+  onAnnotationSelected: (annotation_index: number) => void
+  onStartStopAnnotationClick: () => void
+  onOpenParticipantSelectionClick: () => void
+}
+
+const InstructionsSidebar: React.FC<Props> = (props) => {
+  // We prepare the participants options in the menu
+  const participants_menu_items: MenuProps["items"] = [
+    {
+      key: "1",
+      type: "group",
+      label: "Select participant",
+      children: props.participant_options.map((option: ParticipantOption) => ({
+        key: option.name,
+        label: option.name,
+        icon: option.completed ? <CheckSquareTwoTone /> : <BorderOutlined />,
+        onClick: (item: MenuInfo) => {
+          props.onParticipantSelected(item.key)
+        },
+      })),
+    },
+  ]
+
+  // We prepare the annotations options
+  const annotations_menu_items: MenuProps["items"] = [
+    {
+      key: "1",
+      type: "group",
+      label: "Select annotation",
+      children: props.annotation_options.map((option: AnnotationOption) => ({
+        key: option.index,
+        label: option.category,
+        icon: option.completed ? <CheckSquareTwoTone /> : <BorderOutlined />,
+        onClick: (item: MenuInfo) => {
+          props.onAnnotationSelected(item.key)
+        },
+      })),
+    },
+  ]
+
+  const multiple_annotations_for_selected_participant =
+    props.annotation_options.length > 1
+
+  return (
+    <>
+      <div className={styles["sidebar-block"]}>
+        <h1>Instructions</h1>
+        <h2>
+          <strong>Step 1: </strong>
+          {"Select the camera view where the person below is "}
+          <strong>best visible</strong>
+          {" using the "} {CHANGE_VIEW_PREV_KEY}
+          {" or "}
+          {CHANGE_VIEW_NEXT_KEY}
+          {" keys."}
+        </h2>
+        <SelectedParticipantImage
+          participant={props.selected_participant.name}
+        />
+
+        <h2>
+          <strong>Step 2: </strong>
+          If you have found the participant and selected the best camera view,
+          proceed to Step 3. If you
+          <strong> can't find the person at all</strong>, click the button below
+          which will open a pop-up asking to confirm that the person can't be
+          found. If you confirm, proceed to Step{" "}
+          {multiple_annotations_for_selected_participant ? "5" : "4"}:
+        </h2>
+        <Button
+          type="primary"
+          onClick={props.onCantFindParticipantClick}
+          className={styles["gallery-button"]}
+          icon={<ExclamationCircleOutlined />}
+        >
+          I can't find this participant!
+        </Button>
+        {multiple_annotations_for_selected_participant && (
+          <>
+            <h2>
+              <strong>Step 3: </strong> Select an action that hasn't been
+              annotated and continue to Step 4. If all have been annotated, skip
+              to Step 5.
+            </h2>
+            <Dropdown
+              menu={{ items: annotations_menu_items, selectable: true }}
+            >
+              <Button
+                onClick={(e) => {
+                  e.preventDefault()
+                }}
+                className={styles["action-task-dropwdown-button"]}
+              >
+                <span className={styles["action-task-dropdown-button-text"]}>
+                  <Space>
+                    {props.selected_annotation.completed ? (
+                      <CheckSquareTwoTone />
+                    ) : (
+                      <BorderOutlined />
+                    )}
+                    {props.selected_annotation.category}
+                  </Space>
+                </span>
+                <DownOutlined
+                  className={styles["action-task-dropwdown-button-icon"]}
+                />
+              </Button>
+            </Dropdown>
+          </>
+        )}
+        <h2>
+          <strong>
+            Step {multiple_annotations_for_selected_participant ? "4" : "3"}:{" "}
+          </strong>
+          Start the annotation process. <strong>Get ready! </strong>
+          The video will start playing. During playback, press and{" "}
+          <strong> hold </strong> the{" "}
+          <strong>{`${REGISTER_ACTION_ANNOTATION_KEY}`}</strong> key to indicate
+          the person is <strong>{props.selected_annotation.category}</strong>.
+          Release while they are not ({TIP_EMOJI}
+          <em>
+            You can press <strong>{`${REGISTER_ACTION_ANNOTATION_KEY}`}</strong>{" "}
+            right now, before the annotation process starts, to practice!
+          </em>
+          ). When finished, go to Step{" "}
+          {multiple_annotations_for_selected_participant ? "3" : "4"}.
+        </h2>
+        <Button
+          type="primary"
+          className={styles["gallery-button"]}
+          onClick={props.onStartStopAnnotationClick}
+        >
+          {props.selected_annotation.completed
+            ? "Redo Annotation"
+            : "Start Annotation"}
+        </Button>
+        <h2>
+          <strong>
+            Step {multiple_annotations_for_selected_participant ? "5" : "4"}:{" "}
+          </strong>{" "}
+          Select a participant that hasn't been annotated (without a checkmark{" "}
+          <CheckSquareTwoTone />
+          ). Then, go to Step 1
+        </h2>
+
+        <Dropdown
+          menu={{
+            items: participants_menu_items,
+            selectable: true,
+            className: styles["action-task-dropdown-menu"],
+          }}
+          className={styles["action-task-dropdown"]}
+        >
+          <Button
+            onClick={(e) => {
+              e.preventDefault()
+            }}
+            className={styles["action-task-dropwdown-button"]}
+          >
+            <span className={styles["action-task-dropdown-button-text"]}>
+              <Space>
+                {props.selected_participant.completed ? (
+                  <CheckSquareTwoTone />
+                ) : (
+                  <BorderOutlined />
+                )}
+                {props.selected_participant.name}
+              </Space>
+            </span>
+            <DownOutlined
+              className={styles["action-task-dropwdown-button-icon"]}
+            />
+          </Button>
+        </Dropdown>
+        <Button
+          type="primary"
+          className={styles["gallery-button"]}
+          onClick={props.onOpenParticipantSelectionClick}
+        >
+          Select Participant on Gallery
+        </Button>
+      </div>
+    </>
+  )
+}
+
+export { AnnotationOption, InstructionsSidebar, ParticipantOption }

--- a/covfee/client/tasks/continuous_annotation/task_progress.tsx
+++ b/covfee/client/tasks/continuous_annotation/task_progress.tsx
@@ -1,0 +1,45 @@
+import { ExportOutlined } from "@ant-design/icons"
+import { Progress } from "antd"
+import React from "react"
+
+import styles from "./continous_annotation.module.css"
+
+type Props = {
+  finished: boolean
+  percent: number
+  completionCode: string
+  renderSubmitButton: (extraProps?: any) => React.ReactNode
+}
+
+const TaskProgress: React.FC<Props> = (props) => {
+  return (
+    <div
+      className={styles["sidebar-block"]}
+      style={{ borderWidth: props.finished ? 5 : 1 }}
+    >
+      <h3 className={styles["action-task-progress-text"]}>Task progress</h3>
+      <Progress
+        percent={props.percent}
+        className={styles["action-task-progress-bar"]}
+        format={(percent) => percent.toFixed(1) + "%"}
+      />
+      {props.finished && (
+        <>
+          <p className={styles["action-task-progress-finished-message"]}>
+            Finished! &#x1F389; Your completion code is:
+          </p>
+          <p className={styles["action-task-progress-code"]}>
+            {props.completionCode}
+          </p>
+          {props.renderSubmitButton({
+            disabled: false,
+            className: styles["action-task-progress-completion-button"],
+            icon: <ExportOutlined />,
+          })}
+        </>
+      )}
+    </div>
+  )
+}
+
+export default TaskProgress

--- a/covfee/client/tasks/continuous_annotation/video_overlay_info.tsx
+++ b/covfee/client/tasks/continuous_annotation/video_overlay_info.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { REGISTER_ACTION_ANNOTATION_KEY } from "./constants"
+import styles from "./continous_annotation.module.css"
+
+type Props = {
+  active: boolean
+  annotation_category: string
+}
+
+const VideoOverlayInfo: React.FC<Props> = (props) => {
+  return (
+    <div
+      className={`${styles["action-annotation-flashscreen"]} ${
+        props.active
+          ? styles["action-annotation-flashscreen-active-key-pressed"]
+          : styles["action-annotation-flashscreen-active-key-not-pressed"]
+      }`}
+    >
+      <h1>
+        {props.active ? "" : "NOT"} {props.annotation_category}
+      </h1>
+      <h1>{" (Key: " + REGISTER_ACTION_ANNOTATION_KEY + ")"}</h1>
+    </div>
+  )
+}
+
+export default VideoOverlayInfo


### PR DESCRIPTION
- Improved instructions about practicing with the annotation key before
- Implemented logic to hide the instructions bar on the left and increase the size of the video player annotate
- Created a separate component for the Gallery and the participant image crop
- Created a separate component for the "Instructions sidebar" so the main file is cleaner
- Created a separate component for the TaskProgress so the main file is cleaner
- Created a separate component for the flashscreen
- Minor style modifications, such as reducing the width of the right sidebar

Fixes #23 #22