### PR TITLE
.#23 #33 Improvements to the continuous annotations task UX

### DIFF
--- a/covfee/client/journey/journey.tsx
+++ b/covfee/client/journey/journey.tsx
@@ -281,7 +281,7 @@ export const _JourneyPage: React.FC<Props> = (props) => {
 
       <ContentContainer
         showSideBar={args.showSideBar}
-        height={window.innerHeight}
+        /*height={window.innerHeight}*/
       >
         {hitExtra && (
           <></>

--- a/covfee/client/tasks/continuous_annotation/spec.ts
+++ b/covfee/client/tasks/continuous_annotation/spec.ts
@@ -21,4 +21,5 @@ export interface ContinuousAnnotationTaskSpec extends BaseTaskSpec {
   annotations: AnnotationDataSpec[]
   prolificCompletionCode?: string
   userCanAdd: boolean
+  videoTutorialUrl?: string
 }

--- a/covfee/shared/task_dataclasses.py
+++ b/covfee/shared/task_dataclasses.py
@@ -39,9 +39,10 @@ class ContinuousAnnotationTaskSpec(CovfeeTask):
     # This applies both to multiple clients in the same journey and across journeys.
     # Internally covfee uses socketio to synchronize task state.
     useSharedState: bool
+    videoTutorialUrl: str
     # If true, all journeys must click ready to start the task
     wait_for_ready: bool
-    def __init__(self, annotations, media, name, userCanAdd, countdown = 0, instructions = None, instructions_type = 'default', max_submissions = 0, n_pause = None, n_start = None, prerequisite = False, prolificCompletionCode = None, required = True, timer = None, timer_empty = None, timer_pausable = None, timer_pause = None, useSharedState = None, wait_for_ready = None):
+    def __init__(self, annotations, media, name, userCanAdd, countdown = 0, instructions = None, instructions_type = 'default', max_submissions = 0, n_pause = None, n_start = None, prerequisite = False, prolificCompletionCode = None, required = True, timer = None, timer_empty = None, timer_pausable = None, timer_pause = None, useSharedState = None, videoTutorialUrl = None, wait_for_ready = None):
         """
         ### Parameters
         0. annotations : List[Any]
@@ -80,7 +81,8 @@ If timer reaches zero, the task is set to finished state.
             - If true, the task state will be synced between clients.
 This applies both to multiple clients in the same journey and across journeys.
 Internally covfee uses socketio to synchronize task state.
-        18. wait_for_ready : bool
+        18. videoTutorialUrl : str
+        19. wait_for_ready : bool
             - If true, all journeys must click ready to start the task
         """
 
@@ -104,6 +106,7 @@ Internally covfee uses socketio to synchronize task state.
         self.timer_pausable = timer_pausable
         self.timer_pause = timer_pause
         self.useSharedState = useSharedState
+        self.videoTutorialUrl = videoTutorialUrl
         self.wait_for_ready = wait_for_ready
 
 

--- a/samples/continuous_annotation/continuous_annotation.py
+++ b/samples/continuous_annotation/continuous_annotation.py
@@ -33,6 +33,7 @@ for i in range(3):
         }],
         prolificCompletionCode="D1F2DGU1",
         userCanAdd=False,
+        videoTutorialUrl="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4",
     )
 
     j1 = hit.add_journey(nodes=[my_task_1])


### PR DESCRIPTION
- Video playback can be freely controlled while the there is not an active annotations process using the standard controls
- When the annotations start, the video playback resets to start and video controls are hidden.
- Now hiding the annotation tips when the annotation process stops
- Renamed the playbackStatus variable to convey that it is strongly linked to cam view change events.
- Removed the height prop from the ContentContainer. It was causing clipping issues
- Added a notification each time an annotation buffer is to be uploaded
- Moved the Modal "Can't find participant" dialog to the InstructionsSidebar
- Added a button to open the video tutorial in a separate tab
- Slight improvements on instructions text
- Added an argument to the ContinuousAnnotationTaskSpec to include the video tutorial url