### PR TITLE
.#23 Better guidance related to task completion and accessing a compl…

### DIFF
--- a/covfee/client/journey/journey.tsx
+++ b/covfee/client/journey/journey.tsx
@@ -117,6 +117,12 @@ export const _JourneyPage: React.FC<Props> = (props) => {
   }, [])
 
   const showCompletionInfo = React.useCallback(() => {
+    // FIXME: this implementation ties strongly the submission logic
+    //        with immediately showing this pop up to redirect to prolific.
+    //        Instead, for the continuous annotation task, we wanted to
+    //        allow the user to confirm, to submit, and then decide when
+    //        to redirect, for better user experience.
+    return
     const config = journey.completionInfo
     return Modal.success({
       title: "HIT submitted!",

--- a/covfee/client/tasks/continuous_annotation/continous_annotation.module.css
+++ b/covfee/client/tasks/continuous_annotation/continous_annotation.module.css
@@ -156,6 +156,7 @@
   margin-top: 10px;
   font-weight: "bold";
   font-size: 16px;
+  text-align: center;
 }
 
 .action-task-progress-code {

--- a/covfee/client/tasks/continuous_annotation/index.tsx
+++ b/covfee/client/tasks/continuous_annotation/index.tsx
@@ -31,7 +31,7 @@ import {
 } from "./instructions_sidebar"
 import { State, actions, slice } from "./slice"
 import type { AnnotationDataSpec, ContinuousAnnotationTaskSpec } from "./spec"
-import TaskProgress from "./task_progress"
+import TaskProgress, { TaskAlreadyCompleted } from "./task_progress"
 
 interface Props extends CovfeeTaskProps<ContinuousAnnotationTaskSpec> {}
 
@@ -583,6 +583,15 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
     return <h1>Loading...</h1>
   }
 
+  // Redirection URL once the annotator has completed the entire annotation task.
+  const redirectUrl =
+    "https://app.prolific.com/submissions/complete?cc=" +
+    props.spec.prolificCompletionCode
+
+  if (args.response.submitted) {
+    return <TaskAlreadyCompleted redirectUrl={redirectUrl} />
+  }
+
   return (
     <form>
       <ModalParticipantSelectionGallery
@@ -605,8 +614,9 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
             finished={isEntireTaskCompleted}
             percent={taskCompletionPercentage}
             completionCode={props.spec.prolificCompletionCode}
-            submittButtonCallback={(response: any) => {
-              props.onSubmit(response)
+            redirectUrl={redirectUrl}
+            onSubmit={() => {
+              props.onSubmit({})
               setSubmitted(true)
             }}
             submitButtonDisabled={submitted}

--- a/covfee/client/tasks/continuous_annotation/instructions_sidebar.tsx
+++ b/covfee/client/tasks/continuous_annotation/instructions_sidebar.tsx
@@ -142,7 +142,7 @@ const InstructionsSidebar: React.FC<Props> = (props) => {
               setIsMarkParticipantModalOpen(false)
             }}
           >
-            Yes! the participant is not found
+            I'm sure the participant is not found
           </Button>,
         ]}
       >
@@ -151,8 +151,8 @@ const InstructionsSidebar: React.FC<Props> = (props) => {
             I checked all camera views and I can't find this participant .
           </li>
           <li>
-            I am mostly certain this participant does not enter any view in the
-            middle of playback.
+            I am certain this participant does not enter any view in the middle
+            of playback.
           </li>
         </ul>
       </Modal>

--- a/covfee/client/tasks/continuous_annotation/task_progress.tsx
+++ b/covfee/client/tasks/continuous_annotation/task_progress.tsx
@@ -28,7 +28,6 @@ const TaskProgress: React.FC<Props> = (props) => {
           if (props.redirectUrl) {
             window.location.href = props.redirectUrl
           }
-          //
         },
         onCancel: () => {
           setCheckWhetherToSubmitTask(false)

--- a/covfee/client/tasks/continuous_annotation/task_progress.tsx
+++ b/covfee/client/tasks/continuous_annotation/task_progress.tsx
@@ -1,23 +1,48 @@
-import { Button, Progress } from "antd"
-import React from "react"
+import { Button, Modal, Progress } from "antd"
+import React, { useEffect, useState } from "react"
 
 import styles from "./continous_annotation.module.css"
 
 type Props = {
   finished: boolean
   percent: number
-  completionCode: string
-  submittButtonCallback: (extraProps?: any) => void
+  completionCode?: string
+  redirectUrl?: string
   submitButtonDisabled: boolean
+  onSubmit: () => void
 }
 
 const TaskProgress: React.FC<Props> = (props) => {
+  const [checkWhetherToSubmitTask, setCheckWhetherToSubmitTask] =
+    useState(false)
+
+  useEffect(() => {
+    if (checkWhetherToSubmitTask) {
+      Modal.confirm({
+        title: "Are you sure you want to submit?",
+        content: "You won't be able to change your response after you submit.",
+        okText: "Submit",
+        onOk: () => {
+          setCheckWhetherToSubmitTask(false)
+          props.onSubmit()
+          if (props.redirectUrl) {
+            window.location.href = props.redirectUrl
+          }
+          //
+        },
+        onCancel: () => {
+          setCheckWhetherToSubmitTask(false)
+        },
+      })
+    }
+  }, [checkWhetherToSubmitTask])
+
   return (
     <div
       className={styles["sidebar-block"]}
       style={{ borderWidth: props.finished ? 5 : 1 }}
     >
-      <h3 className={styles["action-task-progress-text"]}>Task progress</h3>
+      <h1 className={styles["action-task-progress-text"]}>Task progress</h1>
       <Progress
         percent={props.percent}
         className={styles["action-task-progress-bar"]}
@@ -25,14 +50,16 @@ const TaskProgress: React.FC<Props> = (props) => {
       />
       {props.finished && (
         <>
+          <h1 className={styles["action-task-progress-finished-message"]}>
+            All annotations are completed! &#x1F389;
+          </h1>
           <p className={styles["action-task-progress-finished-message"]}>
-            Finished! &#x1F389; Your completion code is:
-          </p>
-          <p className={styles["action-task-progress-code"]}>
-            {props.completionCode}
+            To finish, click on the Submit button below.
           </p>
           <Button
-            onClick={props.submittButtonCallback}
+            onClick={() => {
+              setCheckWhetherToSubmitTask(true)
+            }}
             type="primary"
             className={styles["gallery-button"]}
             disabled={props.submitButtonDisabled}
@@ -42,6 +69,35 @@ const TaskProgress: React.FC<Props> = (props) => {
         </>
       )}
     </div>
+  )
+}
+
+type TaskAlreadyCompletedProps = {
+  redirectUrl?: string
+}
+
+export const TaskAlreadyCompleted: React.FC<TaskAlreadyCompletedProps> = (
+  props
+) => {
+  return (
+    <>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "100%",
+        }}
+      >
+        <h2>Your response was already submitted. Thank you!</h2>
+        {props.redirectUrl && (
+          <Button type="primary" href={props.redirectUrl}>
+            Take me to Prolific Academic
+          </Button>
+        )}
+      </div>
+    </>
   )
 }
 


### PR DESCRIPTION
…eted task

- Better guidance to the user when the task is completed. Not showing the completion code, but redirecting to prolific on submit
- Killed the existing prolific academic pop up which was being eventually called with the props.onSubmit logic, and replaced by local logic with better user experience
- Created a TaskAlreadyCompleted component that blocks access to the task (and data therein) when the results have been submitted to covfee
- Minor text improvements.