### PR TITLE
Pilot fixes

### DIFF
--- a/covfee/client/chat/chat.tsx
+++ b/covfee/client/chat/chat.tsx
@@ -1,13 +1,12 @@
-import React, { useContext } from "react"
-import { Chat, ChatMessage, IoChatMessage } from "../types/chat"
-import { AllPropsRequired } from "../types/utils"
-import { styled } from "styled-components"
 import { SendOutlined, WechatOutlined } from "@ant-design/icons"
-import classNames from "classnames"
 import { Empty } from "antd"
-import { appContext } from "../app_context"
-import { getHumanFriendlyDateString } from "../utils"
+import classNames from "classnames"
+import React, { useContext } from "react"
+import { styled } from "styled-components"
 import { chatContext } from "../chat_context"
+import { Chat } from "../types/chat"
+import { AllPropsRequired } from "../types/utils"
+import { getHumanFriendlyDateString } from "../utils"
 
 const getChatName = (chat: Chat) => {
   if (chat.journey_id) {
@@ -103,6 +102,8 @@ const ChatButton = styled.button<{ $chatOpen: boolean; $numUnread: number }>`
   bottom: 0;
   width: 50px;
   height: 50px;
+  /* FIXME: Hide the chat */
+  display: none;
 
   font-size: 2.2em;
   background-color: ${(props) => (props.$chatOpen ? "gray" : "#ddd")};

--- a/covfee/client/chat/chat.tsx
+++ b/covfee/client/chat/chat.tsx
@@ -102,7 +102,7 @@ const ChatButton = styled.button<{ $chatOpen: boolean; $numUnread: number }>`
   bottom: 0;
   width: 50px;
   height: 50px;
-  /* FIXME: Hide the chat */
+  /* FIXME #MINGLE: Force hiding the chat for the mingle experiments using the continuous annotation task */
   display: none;
 
   font-size: 2.2em;

--- a/covfee/client/journey/journey.tsx
+++ b/covfee/client/journey/journey.tsx
@@ -117,7 +117,7 @@ export const _JourneyPage: React.FC<Props> = (props) => {
   }, [])
 
   const showCompletionInfo = React.useCallback(() => {
-    // FIXME: this implementation ties strongly the submission logic
+    // FIXME: #MINGLE this implementation ties strongly the submission logic
     //        with immediately showing this pop up to redirect to prolific.
     //        Instead, for the continuous annotation task, we wanted to
     //        allow the user to confirm, to submit, and then decide when
@@ -247,6 +247,7 @@ export const _JourneyPage: React.FC<Props> = (props) => {
           top: 0,
           width: "100%",
           zIndex: 1000,
+          /* FIXME #MINGLE: Force hiding for the mingle experiments using the continuous annotation task */
           display: "none",
         }}
       >
@@ -341,7 +342,7 @@ const SidebarContainer = styled.div<any>`
   position: sticky;
   display: inline-block;
   vertical-align: top;
-  // top: 46px;
+  // top: 46px; // FIXME #MINGLE: Force hiding for the mingle experiments using the continuous annotation task
   height: calc(100vh);
   width: 25%;
   overflow: auto;
@@ -354,11 +355,14 @@ interface ContentContainerProps {
 
 const ContentContainer = styled.div<ContentContainerProps>`
   position: fixed;
-  // top: 46px;
+  // top: 46px; // FIXME #MINGLE: Force hiding for the mingle experiments using the continuous annotation task
   right: 0;
   display: inline-block;
   vertical-align: top;
-  height: ${(props) => (props.height ? props.height : "calc(100vh)")};
+  height: ${(props) =>
+    props.height
+      ? props.height
+      : "calc(100vh)"}; // FIXME #MINGLE: Force hiding for the mingle experiments using the continuous annotation task
   width: ${(props) => (props.showSideBar ? "calc(100% - 25%)" : "100%")};
   overflow: auto;
 `

--- a/covfee/client/journey/journey.tsx
+++ b/covfee/client/journey/journey.tsx
@@ -242,7 +242,13 @@ export const _JourneyPage: React.FC<Props> = (props) => {
         onClick={handleMenuClick}
         mode="horizontal"
         theme="dark"
-        style={{ position: "sticky", top: 0, width: "100%", zIndex: 1000 }}
+        style={{
+          position: "sticky",
+          top: 0,
+          width: "100%",
+          zIndex: 1000,
+          display: "none",
+        }}
       >
         <Menu.Item key="logo" disabled>
           <CovfeeMenuItem />
@@ -335,8 +341,8 @@ const SidebarContainer = styled.div<any>`
   position: sticky;
   display: inline-block;
   vertical-align: top;
-  top: 46px;
-  height: calc(100vh - 46px);
+  // top: 46px;
+  height: calc(100vh);
   width: 25%;
   overflow: auto;
 `
@@ -348,11 +354,11 @@ interface ContentContainerProps {
 
 const ContentContainer = styled.div<ContentContainerProps>`
   position: fixed;
-  top: 46px;
+  // top: 46px;
   right: 0;
   display: inline-block;
   vertical-align: top;
-  height: ${(props) => (props.height ? props.height : "calc(100vh - 46px)")};
+  height: ${(props) => (props.height ? props.height : "calc(100vh)")};
   width: ${(props) => (props.showSideBar ? "calc(100% - 25%)" : "100%")};
   overflow: auto;
 `

--- a/covfee/client/journey/journey.tsx
+++ b/covfee/client/journey/journey.tsx
@@ -286,6 +286,7 @@ export const _JourneyPage: React.FC<Props> = (props) => {
       )}
 
       <ContentContainer
+        id="JourneyContentContainer"
         showSideBar={args.showSideBar}
         /*height={window.innerHeight}*/
       >

--- a/covfee/client/tasks/continuous_annotation/continous_annotation.module.css
+++ b/covfee/client/tasks/continuous_annotation/continous_annotation.module.css
@@ -99,7 +99,7 @@
 }
 
 .main-content-video-and-guide {
-  padding-top: 22px;
+  padding-top: 2px;
   flex-grow: 1;
   max-width: 85vw;
   max-height: "50px";
@@ -194,6 +194,10 @@
   height: 20vh;
   padding-left: 3%;
   padding-right: 3%;
+}
+
+.instruction-text-during-annotation {
+  font-size: 1rem;
 }
 
 .action-annotation-flashscreen h1 {

--- a/covfee/client/tasks/continuous_annotation/index.tsx
+++ b/covfee/client/tasks/continuous_annotation/index.tsx
@@ -446,11 +446,19 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
       if (!validAnnotationsDataAndSelection) {
         return
       }
+      // Scroll to the top of the page,
+      // on 1080p resolution it doesn't do anything, as the page is as big as the screen,
+      // on 720p or lower, the page is bigger than the screen, so it scrolls to the top.
+      const parentElement = document.getElementById("JourneyContentContainer")
+      parentElement.scrollTo({ top: 0, left: 0, behavior: "instant" })
+
       startVideoPlayback(0.0)
+
       setPlaybackStatusOnCamViewChangeEvent({
         paused: false,
         currentTime: 0.0,
       })
+
       setActiveAnnotationDataArray({
         buffer: Array.from({ length: numberOfVideoFrames() }, () => 0),
         needs_upload: false,

--- a/covfee/client/tasks/continuous_annotation/index.tsx
+++ b/covfee/client/tasks/continuous_annotation/index.tsx
@@ -447,6 +447,10 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
         return
       }
       startVideoPlayback(0.0)
+      setPlaybackStatusOnCamViewChangeEvent({
+        paused: false,
+        currentTime: 0.0,
+      })
       setActiveAnnotationDataArray({
         buffer: Array.from({ length: numberOfVideoFrames() }, () => 0),
         needs_upload: false,

--- a/covfee/client/tasks/continuous_annotation/index.tsx
+++ b/covfee/client/tasks/continuous_annotation/index.tsx
@@ -696,7 +696,7 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
                 <Checkbox
                   style={{
                     color: "white",
-                    fontSize: "18px",
+                    fontSize: "1rem",
                     position: "absolute",
                     bottom: 0,
                     right: 0,

--- a/covfee/client/tasks/continuous_annotation/index.tsx
+++ b/covfee/client/tasks/continuous_annotation/index.tsx
@@ -238,17 +238,28 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
   // We get a reference to the VideoJS player and assign event
   // listeners to it.
   const videoPlayerRef = useRef<VideoJsPlayer>(null)
+  // We keep track of the loadstart event to make React respond to it
+  // based on useEffect calls, because the execution of the loadstart
+  // callback is different between chrome and firefox. In Chrome is
+  // executed after the useEffect calls (when all state is fully updated),
+  // but Firefox executes it before the useEffect calls leading to bugs.
+  const [videoLoadStartEvent, setVideoLoadStartEvent] = useState(null)
+
   const handleVideoPlayerReady = (player: VideoJsPlayer) => {
     videoPlayerRef.current = player
     videoPlayerRef.current.volume(0)
   }
   useEffect(() => {
     if (videoPlayerRef.current) {
+      const handleVideoLoadStart = (event: any) => {
+        // enqueues a useEffect call
+        setVideoLoadStartEvent(event)
+      }
       videoPlayerRef.current.on("ended", handleVideoEnd)
-      videoPlayerRef.current.on("loadstart", handleVideoSourceChange)
+      videoPlayerRef.current.on("loadstart", handleVideoLoadStart)
       return () => {
         videoPlayerRef.current.off("ended", handleVideoEnd)
-        videoPlayerRef.current.off("loadstart", handleVideoSourceChange)
+        videoPlayerRef.current.off("loadstart", handleVideoLoadStart)
       }
     }
   })
@@ -304,7 +315,7 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
 
   // ...and then we ensure that the video player is updated with the playback status
   // when the new video source becomes active.
-  const handleVideoSourceChange = (newSrc: string) => {
+  useEffect(() => {
     if (videoPlayerRef.current) {
       videoPlayerRef.current.currentTime(
         playbackStatusOnCamViewChangeEvent.currentTime
@@ -322,7 +333,7 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
         }
       }
     }
-  }
+  }, [videoLoadStartEvent])
 
   const numberOfVideoFrames = () => {
     if (videoPlayerRef.current) {
@@ -453,11 +464,6 @@ const ContinuousAnnotationTask: React.FC<Props> = (props) => {
       parentElement.scrollTo({ top: 0, left: 0, behavior: "instant" })
 
       startVideoPlayback(0.0)
-
-      setPlaybackStatusOnCamViewChangeEvent({
-        paused: false,
-        currentTime: 0.0,
-      })
 
       setActiveAnnotationDataArray({
         buffer: Array.from({ length: numberOfVideoFrames() }, () => 0),


### PR DESCRIPTION
This PR contains the code that was used to run the first pilot. It has a few hotfixes:

- Hides the chat button
- Fixes a bug where the video wouldn't play when changing camera views
  - To trigger the bug you need to do the following (there is probably a simpler way to reproduce the bug):
    * Change camera views
    * Play video and skip ahead (let the video play)
    * Press S key
    * Click Start annotating
    * Press S key
    * Change camera views
    * The video should continue playing in new camera view but it doesn't
  * The fix was to manually initialise the `setPlaybackStatusOnCamViewChangeEvent` on starting the annotation
* Fixes the layout for 720p by
  * Removing the top bar and the top padding in all the relevant elements
  * Automatically scrolling to the top of the window when starting the annotation
  * Making the font size of the tooltip be relative to the window size