### PR TITLE
.#46 Option to specify an audio requirement during playback

### DIFF
--- a/covfee/client/tasks/continuous_annotation/spec.ts
+++ b/covfee/client/tasks/continuous_annotation/spec.ts
@@ -21,5 +21,10 @@ export interface ContinuousAnnotationTaskSpec extends BaseTaskSpec {
   annotations: AnnotationDataSpec[]
   prolificCompletionCode?: string
   userCanAdd: boolean
+  /**
+   * When specified: True, means audio on is mandatory, False means audio off (muted) is mandatory.
+   * @default null
+   */
+  audioRequirement?: boolean
   videoTutorialUrl?: string
 }

--- a/covfee/shared/task_dataclasses.py
+++ b/covfee/shared/task_dataclasses.py
@@ -7,6 +7,8 @@ class ContinuousAnnotationTaskSpec(CovfeeTask):
     media: List[Any]
     name: str
     userCanAdd: bool
+    # When specified: True, means audio on is mandatory, False means audio off (muted) is mandatory.
+    audioRequirement: bool
     # Seconds countdown after start condition met.
     countdown: float
     # Instructions to be displayed for the node
@@ -42,47 +44,49 @@ class ContinuousAnnotationTaskSpec(CovfeeTask):
     videoTutorialUrl: str
     # If true, all journeys must click ready to start the task
     wait_for_ready: bool
-    def __init__(self, annotations, media, name, userCanAdd, countdown = 0, instructions = None, instructions_type = 'default', max_submissions = 0, n_pause = None, n_start = None, prerequisite = False, prolificCompletionCode = None, required = True, timer = None, timer_empty = None, timer_pausable = None, timer_pause = None, useSharedState = None, videoTutorialUrl = None, wait_for_ready = None):
+    def __init__(self, annotations, media, name, userCanAdd, audioRequirement = None, countdown = 0, instructions = None, instructions_type = 'default', max_submissions = 0, n_pause = None, n_start = None, prerequisite = False, prolificCompletionCode = None, required = True, timer = None, timer_empty = None, timer_pausable = None, timer_pause = None, useSharedState = None, videoTutorialUrl = None, wait_for_ready = None):
         """
         ### Parameters
         0. annotations : List[Any]
         1. media : List[Any]
         2. name : str
         3. userCanAdd : bool
-        4. countdown : float
+        4. audioRequirement : bool
+            - When specified: True, means audio on is mandatory, False means audio off (muted) is mandatory.
+        5. countdown : float
             - Seconds countdown after start condition met.
-        5. instructions : str
+        6. instructions : str
             - Instructions to be displayed for the node
-        6. instructions_type : str
+        7. instructions_type : str
             - How the instructions will be displayed
-        7. max_submissions : float
+        8. max_submissions : float
             - Maximum number of submissions a user can make for the task.
-        8. n_pause : float
+        9. n_pause : float
             - If the number of subjects is n_pause or less, the task will be paused
-        9. n_start : float
+        10. n_start : float
             - Number of jorneys required to start task
-        10. prerequisite : bool
+        11. prerequisite : bool
             - Node is marked as a prerrequisite
 Prerrequisite nodes must be completed before the rests of the nodes in the HIT are revealed.
-        11. prolificCompletionCode : str
-        12. required : bool
+        12. prolificCompletionCode : str
+        13. required : bool
             - If true, this node must have a valid submission before the HIT can be submitted
-        13. timer : float
+        14. timer : float
             - Time to complete the task
-        14. timer_empty : float
+        15. timer_empty : float
             - Empty timer is started everytime the task is empty (no journeys online)
 If the timer reaches zero, the task is set to finished state.
-        15. timer_pausable : bool
+        16. timer_pausable : bool
             - If true, the timer will pause when the task is paused.
-        16. timer_pause : float
+        17. timer_pause : float
             - Pause timer is started every time the task enters paused state
 If timer reaches zero, the task is set to finished state.
-        17. useSharedState : bool
+        18. useSharedState : bool
             - If true, the task state will be synced between clients.
 This applies both to multiple clients in the same journey and across journeys.
 Internally covfee uses socketio to synchronize task state.
-        18. videoTutorialUrl : str
-        19. wait_for_ready : bool
+        19. videoTutorialUrl : str
+        20. wait_for_ready : bool
             - If true, all journeys must click ready to start the task
         """
 
@@ -92,6 +96,7 @@ Internally covfee uses socketio to synchronize task state.
         self.media = media
         self.name = name
         self.userCanAdd = userCanAdd
+        self.audioRequirement = audioRequirement
         self.countdown = countdown
         self.instructions = instructions
         self.instructions_type = instructions_type

--- a/samples/continuous_annotation/continuous_annotation.py
+++ b/samples/continuous_annotation/continuous_annotation.py
@@ -32,6 +32,7 @@ for i in range(3):
             "src": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4",
         }],
         prolificCompletionCode="D1F2DGU1",
+        audioRequirement=False,
         userCanAdd=False,
         videoTutorialUrl="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4",
     )


### PR DESCRIPTION
- Added a dummy state to the videoPlayerready so the useEffect hook runs at least once, and thus event listeners are connected, so we can monitor volume status changes.
- Added a spec item to specify audioRequirement for the task.
- If the video state does not match the audioRequirement, we force it back to the desired state