### PR TITLE
Fix missing annotations in json download

### DIFF
--- a/covfee/server/orm/hit.py
+++ b/covfee/server/orm/hit.py
@@ -20,6 +20,7 @@ from .base import Base
 from .journey import JourneySpec, JourneyInstance
 from .project import Project
 from .node import JourneyNode, NodeInstance, NodeSpec
+from .utils import NoIndentJSONEncoder
 
 
 class HITSpec(Base):
@@ -227,7 +228,10 @@ class HITInstance(Base):
     def stream_download(self, z, base_path):
         results_dict = self.make_results_dict()
         stream = BytesIO()
-        stream.write(json.dumps(results_dict).encode())
+
+        stream.write(
+            json.dumps(results_dict, indent=4, cls=NoIndentJSONEncoder).encode()
+        )
         stream.seek(0)
         z.write_iter(
             os.path.join(

--- a/covfee/server/orm/task.py
+++ b/covfee/server/orm/task.py
@@ -144,13 +144,12 @@ class TaskInstance(NodeInstance):
                 if annotation.data_json is not None
             ]
 
-            if (
-                self.journey_associations is not None
-                and len(self.journey_associations) > 0
-            ):
-                annotator = self.journey_associations[0].journey.annotator
+            prolific_ids = []
+            for journey in self.journeys:
+                annotator = journey.annotator
                 if annotator is not None and annotator.prolific_id is not None:
-                    result_dict["prolific_id"] = [annotator.prolific_id]
+                    prolific_ids.append(annotator.prolific_id)
+            result_dict["prolific_id"] = prolific_ids
 
             results_list.append(result_dict)
 

--- a/covfee/server/orm/task.py
+++ b/covfee/server/orm/task.py
@@ -134,9 +134,27 @@ class TaskInstance(NodeInstance):
         self.get_task_object().on_admin_pause()
 
     def make_results_dict(self):
-        return {
-            "responses": [response.make_results_dict() for response in self.responses]
-        }
+        results_list = []
+        for response in self.responses:
+            result_dict = response.make_results_dict()
+
+            result_dict["annotations"] = [
+                utils.NoIndentJSON(annotation.data_json)
+                for annotation in self.annotations
+                if annotation.data_json is not None
+            ]
+
+            if (
+                self.journey_associations is not None
+                and len(self.journey_associations) > 0
+            ):
+                annotator = self.journey_associations[0].journey.annotator
+                if annotator is not None and annotator.prolific_id is not None:
+                    result_dict["prolific_id"] = [annotator.prolific_id]
+
+            results_list.append(result_dict)
+
+        return {"responses": results_list}
 
 
 # after a TaskInstance is inserted, we attach its

--- a/covfee/server/orm/utils.py
+++ b/covfee/server/orm/utils.py
@@ -36,6 +36,18 @@ class NoIndentJSON(object):
 
 # JSON encoder that avoids indenting any object of type NoIndentList.
 # See https://stackoverflow.com/a/13252112
+# The list of annotations could be very long when formatted in a single column, like so:
+# annotations: { [
+#  0,
+#  0,
+#  ...
+#  0,
+#  0
+# ] }
+#
+# Instead this class allows skipping indentations of any entry that is a
+# subclass of NoIndentJSON, like so:
+# annotations: { [0, 0, ..., 0, 0] }
 class NoIndentJSONEncoder(json.JSONEncoder):
     FORMAT_SPEC = "@@{}@@"
     regex = re.compile(FORMAT_SPEC.format(r"(\d+)"))

--- a/covfee/server/orm/utils.py
+++ b/covfee/server/orm/utils.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Union
 import enum
 from datetime import date, datetime
+import json
+from _ctypes import PyObj_FromPtr
+import re
 
 if TYPE_CHECKING:
     from .node import NodeInstance
@@ -24,3 +27,48 @@ def to_dict(attrib):
         return datetime_to_str(attrib)
     else:
         return attrib
+
+
+class NoIndentJSON(object):
+    def __init__(self, value):
+        self.value = value
+
+
+# JSON encoder that avoids indenting any object of type NoIndentList.
+# See https://stackoverflow.com/a/13252112
+class NoIndentJSONEncoder(json.JSONEncoder):
+    FORMAT_SPEC = "@@{}@@"
+    regex = re.compile(FORMAT_SPEC.format(r"(\d+)"))
+
+    def __init__(self, **kwargs):
+        # Save copy of any keyword argument values needed for use here.
+        self.__sort_keys = kwargs.get("sort_keys", None)
+        super(NoIndentJSONEncoder, self).__init__(**kwargs)
+
+    def default(self, obj):
+        return (
+            self.FORMAT_SPEC.format(id(obj))
+            if isinstance(obj, NoIndentJSON)
+            else super(NoIndentJSONEncoder, self).default(obj)
+        )
+
+    def encode(self, obj):
+        format_spec = self.FORMAT_SPEC  # Local var to expedite access.
+        json_repr = super(NoIndentJSONEncoder, self).encode(obj)  # Default JSON.
+
+        # Replace any marked-up object ids in the JSON repr with the
+        # value returned from the json.dumps() of the corresponding
+        # wrapped Python object.
+        for match in self.regex.finditer(json_repr):
+            # see https://stackoverflow.com/a/15012814/355230
+            id = int(match.group(1))
+            no_indent = PyObj_FromPtr(id)
+            json_obj_repr = json.dumps(no_indent.value, sort_keys=self.__sort_keys)
+
+            # Replace the matched id string with json formatted representation
+            # of the corresponding Python object.
+            json_repr = json_repr.replace(
+                '"{}"'.format(format_spec.format(id)), json_obj_repr
+            )
+
+        return json_repr

--- a/covfee/server/rest_api/projects.py
+++ b/covfee/server/rest_api/projects.py
@@ -86,7 +86,7 @@ def project_download(pid):
     Returns:
         [type]: stream response with a compressed archive. 204 if the project has no responses
     """
-    project = app.session.query(Project).get(pid)
+    project: Project = app.session.query(Project).get(pid)
     if project is None:
         return {"msg": "not found"}, 404
 


### PR DESCRIPTION
This PR adds the annotation data to the json that is downloaded when you click on the "Download results (JSON)" in the admin panel.

The json is formatted  like so:
```json
{
    "hit_id": "35c236724410e66e214c786aad51d9d813bdef9e7203d123ed9ebeddf512e4c1",
    "nodes": {
        "1": {
            "responses": [
                {
                    "created": "2024-05-02 13:07:24.066921",
                    "submitted": "False",
                    "state": {
                        "selectedAnnotationIndex": 0,
                        "mediaPaused": null
                    },
                    "annotations": [],
                    "prolific_id": [
                        "annotator3"
                    ]
                }
            ]
        },
        "2": {
            "responses": [
                {
                    "created": "2024-05-02 13:07:24.066926",
                    "submitted": "False",
                    "state": {
                        "selectedAnnotationIndex": 0,
                        "mediaPaused": null
                    },
                    "annotations": [
                        [0, 0, 0, 0, 0, ........ THIS IS ACTUALLY QUITE LONG, 7200 LINES BUT WITHOUT LINE BREAKS ........., 0, 1, 1]
                   ],
                    "prolific_id": [
                        "annotator1"
                    ]
                }
            ]
        }
    },
    "journeys": [
        {
            "nodes": [
                1
            ]
        },
        {
            "nodes": [
                2
            ]
        },
    ]
}

```