### PR TITLE
.#33 - Support for multiple HITs and using global_unique_id in their …

### DIFF
--- a/covfee/client/admin/hit_block/hit_block.tsx
+++ b/covfee/client/admin/hit_block/hit_block.tsx
@@ -1,10 +1,12 @@
 import * as React from "react"
 import styled from "styled-components"
 
-import { HitInstanceType } from "../../types/hit"
-import { NodeStatus } from "../../types/node"
 import { NodeIndexOutlined } from "@ant-design/icons"
+import classNames from "classnames"
 import { appContext } from "../../app_context"
+import { HitInstanceType } from "../../types/hit"
+import { NodeStatus, NodeType } from "../../types/node"
+import { ForceGraph } from "../force_graph"
 import {
   JourneyColorStatus,
   JourneyColorStatuses,
@@ -16,13 +18,10 @@ import {
   getJourneyStatus,
   getNodeStatus,
 } from "../utils"
-import classNames from "classnames"
-import { ForceGraph } from "../force_graph"
-import { NodeButtons, NodeRow } from "./node_buttons"
-import { HoveringButtons } from "./utils"
-import type { HoveringButtonsArgs } from "./utils"
 import { JourneyRow } from "./journey_buttons"
-import { NodeType } from "../../types/node"
+import { NodeButtons, NodeRow } from "./node_buttons"
+import type { HoveringButtonsArgs } from "./utils"
+import { HoveringButtons } from "./utils"
 interface Props {
   hit: HitInstanceType
 }
@@ -130,7 +129,14 @@ export const HitBlock = (props: Props) => {
       </Header>
       {!collapsed && (
         <div style={{ display: "flex", flexDirection: "row" }}>
-          <div style={{ display: "flex", alignItems: "center", width: "60%" }}>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              width: "60%",
+            }}
+          >
             <NodesList>
               <h2>Nodes</h2>
 
@@ -177,10 +183,11 @@ export const HitBlock = (props: Props) => {
 
               <ul>
                 {props.hit.journeys.map((journey, index) => {
-
                   let journeyNodes: NodeType[] = []
-                  for (const node_idx of journey.nodes) {
-                    journeyNodes.push(props.hit.nodes[node_idx - 1])
+                  for (const node_id of journey.nodes) {
+                    journeyNodes.push(
+                      props.hit.nodes.find((node) => node.id === node_id)
+                    )
                   }
 
                   return (
@@ -251,9 +258,12 @@ const JourneyStatusSummary = NodeStatusSummary
 const GraphContainer = styled.div`
   flex: 1 0 auto;
   max-width: 60%;
+  /* FIXME #CONFLAB: Hiding the GraphContainer because it takes too much space */
+  visibility: hidden;
+  width: 0px;
+  height: 0px;
 `
 const NodesList = styled.div`
-  max-width: 50%;
   flex: 1 0 auto;
   padding: 3px;
 

--- a/covfee/client/admin/projects_page.tsx
+++ b/covfee/client/admin/projects_page.tsx
@@ -25,7 +25,6 @@ const ProjectsPage = (props: Props) => {
   const [projects, setProjects] = React.useState<ProjectType[]>(null)
   const [project, setProject] = React.useState<ProjectType>(null)
 
-  // const [instances, setInstances] = React.useState<HitInstanceType[]>();
   const { clearChats, addChats, clearChatListeners, addChatListeners } =
     React.useContext(chatContext)
 

--- a/covfee/server/orm/hit.py
+++ b/covfee/server/orm/hit.py
@@ -33,7 +33,7 @@ class HITSpec(Base):
     # making it identifiable through multiple launches of "covfee make"
     # and thus being able to add more hits/journeys without destroying
     # the database. It's a string as it is intended to be human-readable
-    id_within_study: Mapped[Optional[str]] = mapped_column(unique=True)
+    global_unique_id: Mapped[Optional[str]] = mapped_column(unique=True)
 
     project_id: Mapped[int] = mapped_column(ForeignKey("projects.id"))
     # project_id = Column(Integer, ForeignKey("projects.name"))

--- a/covfee/server/orm/journey.py
+++ b/covfee/server/orm/journey.py
@@ -34,7 +34,7 @@ class JourneySpec(Base):
     # making it identifiable through multiple launches of "covfee make"
     # and thus being able to add more hits/journeys without destroying
     # the database. It's a string as it is intended to be human-readable
-    id_within_study: Mapped[Optional[str]] = mapped_column(unique=True)
+    global_unique_id: Mapped[Optional[str]] = mapped_column(unique=True)
 
     # spec relationships
     # up

--- a/covfee/server/orm/journey.py
+++ b/covfee/server/orm/journey.py
@@ -167,7 +167,7 @@ class JourneyInstance(Base):
     )
 
     @staticmethod
-    def get_id():
+    def generate_new_id():
         if os.environ.get("COVFEE_ENV") == "dev":
             # return predictable id in dev mode
             # so that URLs don't change on every run
@@ -181,7 +181,7 @@ class JourneyInstance(Base):
 
     def __init__(self):
         super().init()
-        self.id = JourneyInstance.get_id()
+        self.id = JourneyInstance.generate_new_id()
         self.preview_id = hashlib.sha256((self.id + "preview".encode())).digest()
         self.submitted = False
         self.interface = {}

--- a/covfee/shared/dataclass.py
+++ b/covfee/shared/dataclass.py
@@ -89,11 +89,11 @@ class Journey(BaseDataclass):
         else:
             self.nodes_players: List[Tuple[CovfeeTask, int]] = list()
         self.name = name
-        self.id_within_study = global_unique_id
+        self.global_unique_id = global_unique_id
 
     def orm(self):
         journey = OrmJourney([(n.orm(), p) for n, p in self.nodes_players])
-        journey.id_within_study = self.id_within_study
+        journey.global_unique_id = self.global_unique_id
         logger.debug(f"Created ORM journey: {str(journey)}")
         return journey
 
@@ -145,7 +145,7 @@ class HIT(BaseDataclass):
 
     def orm(self):
         hit = OrmHit(self.name, [j.orm() for j in self.journeys])
-        hit.id_within_study = self.global_unique_id
+        hit.global_unique_id = self.global_unique_id
         logger.debug(f"Created ORM HIT: {str(hit)}")
         return hit
 


### PR DESCRIPTION
…definition

- Fixed a bug indexing the nodes assigned to a given HIT in the admin panel
- Hiding the Graph for CONFLAB, which is distracting
- Fixed a bug which was preventing the creation of multiple HITs, as there was a constraint that per row of the HIT the project_id + project_name had to be unique, which did not make sense.
- Now dynamically associating ids to hits in the same way it is done for journeys, through a counter in dev mode and through a secret in deployment