### PR TITLE
.#33 - New support for adding new HITs/Journeys through the spec files

### DIFF
--- a/covfee/cli/commands/launch.py
+++ b/covfee/cli/commands/launch.py
@@ -118,13 +118,19 @@ def make(
     install_npm_packages()
 
     try:
+        # 1. Parse the project spec file into a format that covfee can manage (CovfeeApp)
         loader = Loader(project_spec_file)
-        projects = loader.process(with_spinner=True)
-
-        launcher = Launcher(
-            mode, projects, Path(project_spec_file).parent, auth_enabled=not unsafe
+        covfee_app = loader.load_project_spec_file_and_parse_as_covfee_app(
+            with_spinner=True
         )
-        launcher.make_database(force, with_spinner=True)
+
+        # 2. Create or update the database
+        launcher = Launcher(
+            mode, covfee_app, Path(project_spec_file).parent, auth_enabled=not unsafe
+        )
+        launcher.create_or_update_database(delete_existing_data=force)
+
+        # 3. Launch the app based on the current data/configuration.
         if not no_launch:
             print(
                 get_start_message(

--- a/covfee/launcher.py
+++ b/covfee/launcher.py
@@ -90,6 +90,9 @@ class Launcher:
                 if confirmation.lower() != "yes":
                     print("Aborting...")
                     exit()
+
+                self._make_a_backup_of_the_database_file()
+
             orm.Base.metadata.drop_all(self.engine)
         orm.Base.metadata.create_all(self.engine)
 
@@ -113,7 +116,6 @@ class Launcher:
                 and not delete_existing_data
                 and (session.new or session.dirty or session.deleted)
             ):
-                database_backup_filename = f"{self._database_engine_config.database_file}.backup.{datetime.now().strftime('%Y%m%d%H%M%S')}"
                 user_confirmation_response = input(
                     "The database will be modified. Are you sure you want to continue? (yes/no): "
                 )
@@ -121,18 +123,23 @@ class Launcher:
                     print("Aborting...")
                     exit()
                 else:
-                    logger.info(
-                        f"Creating database backup: {database_backup_filename}..."
-                    )
-                    shutil.copy2(
-                        self._database_engine_config.database_file,
-                        database_backup_filename,
-                    )
+                    self._make_a_backup_of_the_database_file()
             else:
                 logger.info("No database modifications were detected.")
 
             session.commit()
             session.close()
+
+    def _make_a_backup_of_the_database_file(self) -> None:
+        database_backup_filename = f"{self._database_engine_config.database_file}.backup.{datetime.now().strftime('%Y%m%d%H%M%S')}"
+        logger.info(
+                        f"Creating database backup: {database_backup_filename}..."
+                    )
+        shutil.copy2(
+            self._database_engine_config.database_file,
+            database_backup_filename,
+        )
+                
 
     def launch(self, host="0.0.0.0", port=5000):
         if self.environment != "dev":

--- a/covfee/launcher.py
+++ b/covfee/launcher.py
@@ -3,17 +3,25 @@ import platform
 import shutil
 import sys
 from shutil import which
-from typing import List
+from datetime import datetime
 
 from click import Path
 from colorama import Fore
-from halo.halo import Halo
+from covfee.logger import logger
 
 import covfee.server.orm as orm
 from covfee.cli.utils import working_directory
 from covfee.config import Config
 from covfee.server.app import create_app_and_socketio
-from covfee.server.db import get_engine, get_session_local
+from covfee.server.db import (
+    create_database_engine,
+    create_database_sessionmaker,
+    DatabaseEngineConfig,
+)
+from covfee.shared.dataclass import CovfeeApp
+
+from sqlalchemy import Engine
+from sqlalchemy.orm import sessionmaker
 
 
 class ProjectExistsException(Exception):
@@ -25,65 +33,117 @@ class ProjectExistsException(Exception):
 class Launcher:
     """
     Takes care of:
-    1) validating projects
-    2) commiting projects to DB (optional)
+    1) validating orm_initialization_data
+    2) commiting orm_initialization_data to DB (optional)
     3) launching covfee in 'local' or 'dev' mode
     """
 
-    # holds valid projects
-    projects: List["orm.Project"]
+    # holds valid _orm_initialization_data
+    environment: str
+    config: Config
+    _covfee_app: CovfeeApp
+    folder: Path
+    auth_enabled: bool
+    engine: Engine
+    _sessionmaker: sessionmaker
+    _database_modifications_should_be_manually_confirmed: bool = False
+    _database_engine_config: DatabaseEngineConfig
 
     def __init__(
         self,
         environment,
-        projects: List["orm.Project"] = [],
+        covfee_app: CovfeeApp,
         folder: Path = None,
         auth_enabled: bool = True,
     ):
         self.environment = environment
+        self._covfee_app = covfee_app
         self.config = Config(environment)
-        self.projects = projects
         self.folder = folder
         self.auth_enabled = auth_enabled
 
-        self.engine = get_engine(
-            in_memory=(environment == "dev"), db_path=self.config["DATABASE_PATH"]
-        )
-        self.session_local = get_session_local(self.engine)
+        if environment != "dev":
+            self._database_engine_config = DatabaseEngineConfig(
+                database_file=self.config["DATABASE_PATH"],
+            )
+            self._database_modifications_should_be_manually_confirmed = os.path.exists(
+                self._database_engine_config.database_file
+            )
+        else:
+            # In memory database for development and debugging
+            self._database_engine_config = DatabaseEngineConfig()
 
-    def make_database(self, force=False, with_spinner=False):
-        self.init_folder()
-        self.create_tables(drop=force)
-        self.create_admin()
-        if not force:
-            with Halo(
-                text="Looking for existing projects",
-                spinner="dots",
-                enabled=with_spinner,
-            ) as spinner:
-                try:
-                    self.check_conficts()
-                except ProjectExistsException as ex:
-                    spinner.fail("Conflicts found")
-                    raise ex
+        self.engine = create_database_engine(self._database_engine_config)
+        self._sessionmaker = create_database_sessionmaker(self.engine)
 
-        self.commit()
+    def create_or_update_database(self, delete_existing_data: bool = False):
+        # 1. Create the folders for the database and media
+        os.makedirs(os.path.join(self.folder, ".covfee"), exist_ok=True)
+        os.makedirs(os.path.join(self.folder, "www", "media"), exist_ok=True)
+
+        # 2. Delete old tables if "delete_existing_data" is True. Then create tables.
+        if delete_existing_data:
+            if self._database_modifications_should_be_manually_confirmed:
+                confirmation = input(
+                    "Are you sure you want to delete existing database tables? (yes/no): "
+                )
+                if confirmation.lower() != "yes":
+                    print("Aborting...")
+                    exit()
+            orm.Base.metadata.drop_all(self.engine)
+        orm.Base.metadata.create_all(self.engine)
+
+        # 3. Create the admin user if required and not existing in the database
+        self._create_admin_user_in_database_if_needed()
+
+        with self._sessionmaker() as session:
+            # 4. Now, we update the database according to the covfee app specification
+            #    given by the user. If the projects already existed, then it either
+            #    keeps the database as is, or, if the user is adding more HITs/Journeys
+            #    through the global_unique_id mechanic, then it updates the database with
+            #    new HITs/Journeys with global_unique_ids which are not already in the database.
+            #    All the others are ignored/kept as is.
+            self._covfee_app.add_to_database_new_or_updated_projects_specifications_and_instances(
+                session
+            )
+
+            # 5. Prior to commit the changes, check with the user that this is intentional.
+            if (
+                self._database_modifications_should_be_manually_confirmed
+                and not delete_existing_data
+                and (session.new or session.dirty or session.deleted)
+            ):
+                database_backup_filename = f"{self._database_engine_config.database_file}.backup.{datetime.now().strftime('%Y%m%d%H%M%S')}"
+                user_confirmation_response = input(
+                    "The database will be modified. Are you sure you want to continue? (yes/no): "
+                )
+                if user_confirmation_response.lower() != "yes":
+                    print("Aborting...")
+                    exit()
+                else:
+                    logger.info(
+                        f"Creating database backup: {database_backup_filename}..."
+                    )
+                    shutil.copy2(
+                        self._database_engine_config.database_file,
+                        database_backup_filename,
+                    )
+            else:
+                logger.info("No database modifications were detected.")
+
+            session.commit()
+            session.close()
 
     def launch(self, host="0.0.0.0", port=5000):
         if self.environment != "dev":
             self.link_bundles()
 
-        socketio, app = create_app_and_socketio(self.environment, self.session_local)
+        socketio, app = create_app_and_socketio(self.environment, self._sessionmaker)
         with app.app_context():
             app.config["UNSAFE_MODE_ON"] = not self.auth_enabled
             self._start_server(socketio, app, host, port)
 
-    def create_tables(self, drop=False):
-        if drop:
-            orm.Base.metadata.drop_all(self.engine)
-        orm.Base.metadata.create_all(self.engine)
-
-    def create_admin(self):
+    def _create_admin_user_in_database_if_needed(self):
         default_username = self.config["DEFAULT_ADMIN_USERNAME"]
         default_password = self.config["DEFAULT_ADMIN_PASSWORD"]
         if "ADMIN_USERNAME" in self.config and "ADMIN_PASSWORD" in self.config:
@@ -98,7 +158,7 @@ class Launcher:
                 raise ValueError(
                     'Default admin credentials "admin:admin" have not been changed. Please change username and password in config when deploying with authentication.'
                 )
-            with self.session_local() as session:
+            with self._sessionmaker() as session:
                 user = orm.User.by_username(session, username)
                 if user is not None:
                     return
@@ -137,34 +197,6 @@ class Launcher:
             os.system(f"open {target_url}")
         else:
             print(Fore.GREEN + f" * covfee is available at {target_url}")
-
-    def check_conficts(self, with_spinner=False):
-        with self.session_local() as session:
-            for project in self.projects:
-                existing_project = orm.Project.by_name(session, project.name)
-                if existing_project:
-                    raise ProjectExistsException(project.name)
-
-    def commit(self):
-        with self.session_local() as session:
-            for project in self.projects:
-                existing_project = orm.Project.by_name(session, project.name)
-
-                if existing_project:
-                    session.delete(existing_project)
-            session.commit()
-
-            for project in self.projects:
-                session.add(project)
-            session.commit()
-
-    def init_folder(self):
-        covfee_hidden = os.path.join(self.folder, ".covfee")
-        if not os.path.exists(covfee_hidden):
-            os.makedirs(covfee_hidden)
-        media_path = os.path.join(self.folder, "www", "media")
-        if not os.path.exists(media_path):
-            os.makedirs(media_path)
 
     def link_bundles(self):
         master_bundle_path = os.path.join(self.config["MASTER_BUNDLE_PATH"], "main.js")

--- a/covfee/loader.py
+++ b/covfee/loader.py
@@ -3,7 +3,7 @@ import sys
 import json
 import importlib
 from pathlib import Path
-from typing import List
+from typing import List, Dict
 
 from flask import current_app as app
 from halo import Halo
@@ -14,6 +14,8 @@ from covfee.server.orm.user import User, password_hash
 from covfee.cli.utils import working_directory
 from covfee.shared.schemata import Schemata
 from covfee.shared.validator.ajv_validator import AjvValidator
+from covfee.shared.dataclass import CovfeeApp
+from covfee.shared.dataclass import Project as ProjectSpec
 from covfee.server.orm.project import Project
 
 colorama_init()
@@ -30,82 +32,109 @@ def cli_create_tables():
 class Loader:
     """Translates between different covfee file formats"""
 
-    def __init__(self, project_spec_file=None):
+    _project_spec_file: Path
+    _project_spec_from_python_file: bool
+
+    def __init__(self, project_spec_file: str):
         if not os.path.exists(project_spec_file):
             raise FileNotFoundError("covfee file not found.")
 
-        self.project_spec_file = Path(project_spec_file)
-        self.file_extension = self.project_spec_file.suffix
-        if self.file_extension not in [".py", ".json"]:
-            raise ValueError(f"Unsupported file extension {self.file_extension}")
+        self._project_spec_file = Path(project_spec_file)
+        self._project_spec_from_python_file = self._project_spec_file.suffix == ".py"
 
-        self.working_dir = self.project_spec_file.parent
-        self.projects = []
+        if (
+            not self._project_spec_from_python_file
+            and self._project_spec_file.suffix != ".json"
+        ):
+            raise ValueError(
+                f"Unsupported covfee project specification file type {project_spec_file}"
+            )
 
-    def json_parse(self, with_spinner=True):
-        with Halo(
-            text=f"Parsing file {self.project_spec_file} as json..",
-            spinner="dots",
-            enabled=with_spinner,
-        ) as spinner:
-            try:
-                project_spec = json.load(open(self.project_spec_file))
-            except Exception as e:
-                spinner.fail(
-                    f"Error parsing file {self.project_spec_file} as JSON. Are you sure it is valid json?"
-                )
-                raise e
-
-            self.projects.append(project_spec)
-            spinner.succeed(f"Read covfee file {self.project_spec_file}.")
-
-    def json_validate(self, with_spinner=False):
-        filter = AjvValidator()
-        for project_spec in self.projects:
-            with Halo(
-                text=f'Validating project {project_spec["name"]}',
-                spinner="dots",
-                enabled=with_spinner,
-            ) as spinner:
-                try:
-                    filter.validate_project(project_spec)
-                except Exception as e:
-                    spinner.fail(
-                        f'Error validating project "{project_spec["name"]}".\n'
-                    )
-                    raise e
-                spinner.succeed(f'Project "{project_spec["name"]}" is valid.')
-
-    def json_make(self, with_spinner=False):
-        projects = []
-        for project_spec, cf in self.projects:
-            with Halo(
-                text=f'Making project {project_spec["name"]} from file {cf}',
-                spinner="dots",
-                enabled=with_spinner,
-            ) as spinner:
-                projects.append(Project(**project_spec))
-                spinner.succeed(
-                    f'Project {project_spec["name"]} created successfully from file {cf}'
-                )
-
-    def python_load(self):
-        if os.getcwd() not in sys.path:
-            sys.path.append(os.getcwd())
-        module = importlib.import_module(self.project_spec_file.stem)
-        app = getattr(module, "app")
-        self.projects += app.get_instantiated_projects()
-
-    def process(self, with_spinner=False) -> List[Project]:
-        if self.file_extension == ".py":
-            self.python_load()
+    def load_project_spec_file_and_parse_as_covfee_app(
+        self, with_spinner=False
+    ) -> CovfeeApp:
+        covfee_app: CovfeeApp
+        if self._project_spec_from_python_file:
+            covfee_app = self._load_covfee_app_from_python_module()
         else:
-            # validate the covfee files
             schema = Schemata()
             if not schema.exists():
                 schema.make()
 
-            self.json_parse(with_spinner)
-            self.validate(with_spinner)
-            self.json_make(with_spinner)
-        return self.projects
+            projects_json_specs: List[Dict] = (
+                self._load_projects_json_specs_from_json_file(with_spinner)
+            )
+            self._raise_exception_if_projects_json_specs_are_not_valid(
+                projects_json_specs, with_spinner
+            )
+            covfee_app = self._parse_projects_json_specs_into_covfee_app(
+                projects_json_specs, with_spinner
+            )
+
+        return covfee_app
+
+    def _load_projects_json_specs_from_json_file(self, with_spinner=True) -> List[Dict]:
+        projects_json_specs: List[Dict] = []
+        with Halo(
+            text=f"Parsing file {self._project_spec_file} as json..",
+            spinner="dots",
+            enabled=with_spinner,
+        ) as spinner:
+            try:
+                project_json_specs: Dict = json.load(open(self._project_spec_file))
+            except Exception as e:
+                spinner.fail(
+                    f"Error parsing file {self._project_spec_file} as JSON. Are you sure it is valid json?"
+                )
+                raise e
+
+            projects_json_specs.append(project_json_specs)
+            spinner.succeed(f"Read covfee file {self._project_spec_file}.")
+        return projects_json_specs
+
+    def _raise_exception_if_projects_json_specs_are_not_valid(
+        self, projects_json_specs: List[Dict], with_spinner=False
+    ) -> None:
+        filter = AjvValidator()
+        for project_json_specs in projects_json_specs:
+            with Halo(
+                text=f'Validating project {project_json_specs["name"]}',
+                spinner="dots",
+                enabled=with_spinner,
+            ) as spinner:
+                try:
+                    filter.validate_project(project_json_specs)
+                except Exception as e:
+                    spinner.fail(
+                        f'Error validating project "{project_json_specs["name"]}".\n'
+                    )
+                    raise e
+                spinner.succeed(f'Project "{project_json_specs["name"]}" is valid.')
+
+    def _parse_projects_json_specs_into_covfee_app(
+        self, projects_json_specs: List[Dict], with_spinner=False
+    ) -> CovfeeApp:
+        raise NotImplementedError
+        # FIXME: ...this function was broken, but was modified to provide a skeleton of what's needed.
+        #        ... moreover, the previous version of the code was very unclear regarding what cf is
+        #        ...supposed to be and whether it is inside the json data, or somehow added to "self.projects"
+        projects_specs: List[ProjectSpec] = []
+        for project_json_spec, cf in projects_json_specs:
+            with Halo(
+                text=f'Making project {project_json_spec["name"]} from file {cf}',
+                spinner="dots",
+                enabled=with_spinner,
+            ) as spinner:
+
+                projects_specs.append(ProjectSpec(**project_json_spec))
+                spinner.succeed(
+                    f'Project {project_json_spec["name"]} created successfully from file {cf}'
+                )
+        return CovfeeApp(projects_specs)
+
+    def _load_covfee_app_from_python_module(self) -> CovfeeApp:
+        if os.getcwd() not in sys.path:
+            sys.path.append(os.getcwd())
+        module = importlib.import_module(self._project_spec_file.stem)
+        app: CovfeeApp = getattr(module, "app")
+        return app

--- a/covfee/loader.py
+++ b/covfee/loader.py
@@ -51,7 +51,7 @@ class Loader:
             )
 
     def load_project_spec_file_and_parse_as_covfee_app(
-        self, with_spinner=False
+        self, with_spinner: bool=False
     ) -> CovfeeApp:
         covfee_app: CovfeeApp
         if self._project_spec_from_python_file:
@@ -73,7 +73,7 @@ class Loader:
 
         return covfee_app
 
-    def _load_projects_json_specs_from_json_file(self, with_spinner=True) -> List[Dict]:
+    def _load_projects_json_specs_from_json_file(self, with_spinner: bool=True) -> List[Dict]:
         projects_json_specs: List[Dict] = []
         with Halo(
             text=f"Parsing file {self._project_spec_file} as json..",
@@ -93,7 +93,7 @@ class Loader:
         return projects_json_specs
 
     def _raise_exception_if_projects_json_specs_are_not_valid(
-        self, projects_json_specs: List[Dict], with_spinner=False
+        self, projects_json_specs: List[Dict], with_spinner: bool=False
     ) -> None:
         filter = AjvValidator()
         for project_json_specs in projects_json_specs:
@@ -112,7 +112,7 @@ class Loader:
                 spinner.succeed(f'Project "{project_json_specs["name"]}" is valid.')
 
     def _parse_projects_json_specs_into_covfee_app(
-        self, projects_json_specs: List[Dict], with_spinner=False
+        self, projects_json_specs: List[Dict], with_spinner: bool=False
     ) -> CovfeeApp:
         raise NotImplementedError
         # FIXME: ...this function was broken, but was modified to provide a skeleton of what's needed.

--- a/covfee/server/app.py
+++ b/covfee/server/app.py
@@ -27,7 +27,7 @@ from typing import Optional
 
 
 def create_app_and_socketio(
-    mode="deploy", session_local: Optional[sessionmaker] = None
+    mode: str = "deploy", session_local: Optional[sessionmaker] = None
 ):
     # called once per process
     # but reused across threads
@@ -199,7 +199,9 @@ def prolific():
                 id=prolific_annotator_id,
             )
     else:
-        non_finished_journey_instances_query = app.session.query(JourneyInstance).filter(
+        non_finished_journey_instances_query = app.session.query(
+            JourneyInstance
+        ).filter(
             not_(
                 JourneyInstance.status.in_(
                     [JourneyInstanceStatus.FINISHED, JourneyInstanceStatus.DISABLED]
@@ -210,8 +212,11 @@ def prolific():
         journey_instance: JourneyInstance
         for journey_instance in non_finished_journey_instances_query.all():
             # We ignore finished or disabled journeys
-            if (journey_instance.annotator is None or
-                journey_instance.annotator.prolific_id in prolific_ids_for_returned_participants):
+            if (
+                journey_instance.annotator is None
+                or journey_instance.annotator.prolific_id
+                in prolific_ids_for_returned_participants
+            ):
                 # TODO: In the next iteration of this logic we want to achieve two things
                 # 1) For a completed journey, we want to keep a record of the annotator id,
                 #    regardless of whether the annotator is assigned to another journey to work on

--- a/covfee/server/db.py
+++ b/covfee/server/db.py
@@ -1,21 +1,43 @@
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, Engine
 from sqlalchemy.orm import sessionmaker
 
+from typing import Optional, NamedTuple, Union
 
-def get_engine(in_memory=False, db_path=None, echo=False):
-    if in_memory:
+
+class DatabaseEngineConfig(NamedTuple):
+    # The path to the database file, if not provided, the database will be in-memory
+    database_file: Optional[str] = None
+
+    # Whether to display the SQL commands being executed
+    echo_sql_commands: bool = False
+
+
+def create_database_engine(config: DatabaseEngineConfig) -> Engine:
+    """
+    Creates an SQLAlchemy engine attached to the database file specified in the config
+    """
+    if config.database_file:
+        print(f"Creating file system engine at {config.database_file}")
+        return create_engine(
+            f"sqlite:///{config.database_file}", echo=config.echo_sql_commands
+        )
+    else:
         print(f"Creating in-memory engine")
         return create_engine(
             "sqlite:///file:test?mode=memory&cache=shared&uri=true",
             connect_args={"check_same_thread": False},
-            echo=echo,
+            echo=config.echo_sql_commands,
         )
-    else:
-        assert db_path is not None
-        print(f"Creating file system engine at {db_path}")
-        return create_engine(f"sqlite:///{db_path}")
 
 
-def get_session_local(engine=None, **kwargs):
-    engine = get_engine(**kwargs) if engine is None else engine
+def create_database_sessionmaker(engine: Union[Engine, DatabaseEngineConfig]) -> sessionmaker:
+    """
+    Generates the SQLAlchemy sessionmaker for to generate sessions
+
+    Parameters:
+    - engine (Engine | DatabaseEngineConfig): The engine to use for the sessionmaker. If a
+      DatabaseEngineConfig is provided, it will be used to create the engine.
+    """
+    if isinstance(engine, DatabaseEngineConfig):
+        engine = create_database_engine(engine)
     return sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/covfee/server/orm/project.py
+++ b/covfee/server/orm/project.py
@@ -34,10 +34,6 @@ class Project(Base):
         self.email = email
         self.hitspecs = hitspecs
 
-        # to keep track of info at launch time
-        self._conflicts = False
-        self._filename = None
-
     def get_dataframe(self):
         rows = list()
         for hit in self.hitspecs:
@@ -47,9 +43,11 @@ class Project(Base):
                         {
                             "hit_name": hit.name,
                             "hit_id": instance.id.hex(),
-                            "journey_name": journey.spec.name
-                            if journey.spec.name is not None
-                            else "unnamed",
+                            "journey_name": (
+                                journey.spec.name
+                                if journey.spec.name is not None
+                                else "unnamed"
+                            ),
                             "journey_id": journey.id,
                             "url": journey.get_url(),
                             "completion_code": journey.get_completion_code(),

--- a/covfee/shared/dataclass.py
+++ b/covfee/shared/dataclass.py
@@ -1,6 +1,8 @@
 from typing import Any, List, Tuple, Optional
 
-import covfee.launcher as launcher
+from sqlalchemy.orm import scoped_session
+from sqlalchemy import select
+
 from covfee.logger import logger
 from covfee.server.orm import (
     HITSpec as OrmHit,
@@ -14,6 +16,8 @@ from covfee.server.orm import (
 from covfee.server.orm import (
     TaskSpec as OrmTask,
 )
+from covfee.server.orm import HITInstance, JourneyInstance
+import os
 
 
 class PostInitCaller(type):
@@ -28,12 +32,14 @@ class BaseDataclass:
 
 
 class CovfeeTask(BaseDataclass, metaclass=PostInitCaller):
+    _orm_task: Optional[OrmTask] = None
+    _player_count: int
+
     def __init__(self):
         super().__init__()
-        self._orm_task = None
         self._player_count = -1
 
-    def orm(self):
+    def create_orm_task_object(self) -> OrmTask:
         if self._orm_task is not None:
             return self._orm_task
         spec = {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
@@ -87,12 +93,14 @@ class Journey(BaseDataclass):
         if nodes is not None:
             self.nodes_players = [(n, n._count()) for n in nodes]
         else:
-            self.nodes_players: List[Tuple[CovfeeTask, int]] = list()
+            self.nodes_players = []
         self.name = name
         self.global_unique_id = global_unique_id
 
-    def orm(self):
-        journey = OrmJourney([(n.orm(), p) for n, p in self.nodes_players])
+    def create_orm_journey_object(self) -> OrmJourney:
+        journey = OrmJourney(
+            [(n.create_orm_task_object(), p) for n, p in self.nodes_players]
+        )
         journey.global_unique_id = self.global_unique_id
         logger.debug(f"Created ORM journey: {str(journey)}")
         return journey
@@ -138,47 +146,151 @@ class HIT(BaseDataclass):
 
         self.config = config
 
-    def add_journey(self, nodes=None, journey_global_unique_id: Optional[str] = None):
+    def add_journey(
+        self, nodes=None, journey_global_unique_id: Optional[str] = None
+    ) -> Journey:
         j = Journey(nodes, global_unique_id=journey_global_unique_id)
         self.journeys.append(j)
         return j
 
-    def orm(self):
-        hit = OrmHit(self.name, [j.orm() for j in self.journeys])
+    def create_orm_hit_object(self) -> OrmHit:
+        hit = OrmHit(self.name, [j.create_orm_journey_object() for j in self.journeys])
         hit.global_unique_id = self.global_unique_id
         logger.debug(f"Created ORM HIT: {str(hit)}")
         return hit
 
 
 class Project(BaseDataclass):
+    name: str
+    email: str
+    hits: List[HIT]
+
     def __init__(self, name: str, email: str, hits: HIT = None):
         super().__init__()
         self.name = name
         self.email = email
         self.hits = hits if hits is not None else list()
 
-    def orm(self):
-        project = OrmProject(self.name, self.email, [h.orm() for h in self.hits])
-        logger.debug(f"Created ORM Project: {str(project)}")
+    def create_or_update_orm_specs_data(self, session: scoped_session) -> OrmProject:
+        project: Optional[OrmProject] = session.execute(
+            select(OrmProject).filter_by(name=self.name)
+        ).scalar_one_or_none()
+        if project is not None:
+            logger.info(
+                f"Project {self.name} already exists! Will only accept HITs/Journeys with new global_unique_ids."
+            )
+            project.email = self.email
+
+            for new_hit in self.hits:
+                if new_hit.global_unique_id is None:
+                    continue
+                hitspec_in_db: Optional[OrmHit] = session.execute(
+                    select(OrmHit).filter_by(global_unique_id=new_hit.global_unique_id)
+                ).scalar_one_or_none()
+                if hitspec_in_db is not None:
+                    logger.info(
+                        f"HIT {new_hit.global_unique_id} already exists. Checking whether to add new journeys."
+                    )
+                    for journey in new_hit.journeys:
+                        if journey.global_unique_id is None:
+                            logger.info(
+                                f"Cant' add new journeys to HIT without a global_unique_id. Skipping..."
+                            )
+                            continue
+                        journey_in_db = session.execute(
+                            select(OrmJourney).filter_by(
+                                global_unique_id=journey.global_unique_id
+                            )
+                        ).scalar_one_or_none()
+                        if journey_in_db is not None:
+                            logger.info(
+                                f"Journey {journey.global_unique_id} already exists. Skipping..."
+                            )
+                        else:
+                            logger.info(
+                                f"Journey {journey.global_unique_id} being created."
+                            )
+                            journey_orm = journey.create_orm_journey_object()
+                            hitspec_in_db.append_journeyspecs([journey_orm])
+                else:
+                    project.hitspecs.append(new_hit.create_orm_hit_object())
+        else:
+            logger.info(
+                f"Project {self.name} did not exist. Will be created from scratch as is."
+            )
+            project = OrmProject(
+                self.name, self.email, [h.create_orm_hit_object() for h in self.hits]
+            )
+            logger.debug(f"Created ORM Project: {str(project)}")
         return project
+
+    def create_orm_instances_for_hitspecs_journeyspecs_without_instances(
+        self, orm_project: OrmProject, session: scoped_session
+    ) -> OrmProject:
+        # Note: this implementation will create instances
+        if os.environ.get("COVFEE_ENV") == "dev":
+            # In dev mode, instances ids are explicitly set through a ClassVar counter.
+            # In case the project already exists with prior instances, we need to update
+            # that counter relying on what is in the database.
+            # already existed, with previous instances, we
+            HITInstance.instance_counter = session.query(HITInstance).count() + 1
+            JourneyInstance.instance_counter = (
+                session.query(JourneyInstance).count() + 1
+            )
+
+        for hitspec in orm_project.hitspecs:
+            if len(hitspec.instances) == 0:
+                hitspec.instantiate()
+                for hit_instance in hitspec.instances:
+                    for node in hit_instance.nodes:
+                        # FIXME - It's unclear why chats are not being added when the
+                        #         updated orm_project is added to the session.
+                        session.add(node.chat)
+            else:
+                # We check now whether the hit instances are missing journey instances
+                for hit_instance in hitspec.instances:
+                    # We collect the journeyspecs without their own instances
+                    journeyspecs_without_instances = [
+                        journey_spec
+                        for journey_spec in hitspec.journeyspecs
+                        if len(journey_spec.journeys) == 0
+                    ]
+                    if len(journeyspecs_without_instances) > 0:
+                        hit_instance.instantiate_new_journeys(
+                            journeyspecs_without_instances
+                        )
+                        for node in hit_instance.nodes:
+                            # FIXME - It's unclear why chats are not being added when the
+                            #         updated orm_project is added to the session.
+                            session.add(node.chat)
 
 
 class CovfeeApp(BaseDataclass):
-    def __init__(self, projects: List[Project]):
+    _projects_specs: List[Project]
+
+    def __init__(self, projects: List[Project]) -> None:
         super().__init__()
-        self.projects = projects
+        self._projects_specs = projects
 
-    def get_instantiated_projects(self, num_instances=1):
-        orm_projects = []
-        for p in self.projects:
-            orm_project = p.orm()
-            for spec in orm_project.hitspecs:
-                spec.instantiate(num_instances)
-            orm_projects.append(orm_project)
-        return orm_projects
+    def add_to_database_new_or_updated_projects_specifications_and_instances(
+        self, session: scoped_session
+    ) -> List[OrmProject]:
+        """
+        If a session is provided, it is assumed that the related projects could already exist and we
+        could potentially be committing new specs and their related instances.
+        """
+        for project_specs in self._projects_specs:
+            # We first create or update the project specs data, meaning the respective
+            # hitspecs and journeyspecs. If the project is new, it will create data for
+            # all provided HITs. Otherwise, it will create specs only for new HITs
+            # or journeys with global_unique_ids.
+            orm_project = project_specs.create_or_update_orm_specs_data(session)
 
-    def launch(self, num_instances=1):
-        orm_projects = self.get_instantiated_projects(num_instances)
-        l = launcher.Launcher("dev", orm_projects, folder=None)
-        l.make_database()
-        l.launch()
+            # We then create instances for hitspecs and journeyspecs without instances.
+            # This is equally valid for a newly created project, or the newly created specs
+            # for an existing project.
+            project_specs.create_orm_instances_for_hitspecs_journeyspecs_without_instances(
+                orm_project, session
+            )
+
+            session.add(orm_project)

--- a/covfee/shared/dataclass.py
+++ b/covfee/shared/dataclass.py
@@ -183,6 +183,7 @@ class Project(BaseDataclass):
 
             for new_hit in self.hits:
                 if new_hit.global_unique_id is None:
+                    logger.info("HIT missing global_unique_id. Skipping...")
                     continue
                 hitspec_in_db: Optional[OrmHit] = session.execute(
                     select(OrmHit).filter_by(global_unique_id=new_hit.global_unique_id)


### PR DESCRIPTION
- Currently covfee allows to build projects based on a spec file, that is mostly a python file that the study manager uses to create a CovfeeApp specification. However, in practice, studies sometimes have the requirement that new hits are needed because of multiple reasons: perhaps more annotators are required, or more data needs to be annotated, or a specific journey was poorly done. So we need functionality to add new hits.
- This new functionality was created based on two principles: 1) HITs and Journeys can now be uniquely identified by the study manager thorugh sequential runs of covfee make; 2) If HITs/Journeys with new ids are detected, these get instantiated and committed to the database, and thus extending the study.
- The loader and launcher were refactored, with the responsibility of creating and updated orm objects delegated to the Launcher, exclusively, whereas Loader is only about parsing spec files
- Added functionality to confirm database changes and creating backups, whenever not working in dev mode.