### PR TITLE
Fix possible mismatch between participant id annotation in json download

### DIFF
--- a/covfee/server/orm/hit.py
+++ b/covfee/server/orm/hit.py
@@ -243,6 +243,7 @@ class HITInstance(Base):
     def make_results_dict(self):
         return {
             "hit_id": self.id.hex(),
+            "global_unique_id": self.spec.global_unique_id,
             "nodes": {node.id: node.make_results_dict() for node in self.nodes},
             "journeys": [journey.make_results_dict() for journey in self.journeys],
         }

--- a/covfee/server/orm/journey.py
+++ b/covfee/server/orm/journey.py
@@ -271,4 +271,4 @@ class JourneyInstance(Base):
         return instance_dict
 
     def make_results_dict(self):
-        return {"nodes": [node.id for node in self.nodes]}
+        return {"nodes": [node.id for node in self.nodes], "global_unique_id": self.spec.global_unique_id}

--- a/covfee/server/orm/task.py
+++ b/covfee/server/orm/task.py
@@ -138,18 +138,25 @@ class TaskInstance(NodeInstance):
         for response in self.responses:
             result_dict = response.make_results_dict()
 
-            result_dict["annotations"] = [
-                utils.NoIndentJSON(annotation.data_json)
-                for annotation in self.annotations
-                if annotation.data_json is not None
-            ]
+            # FIXME: #CONFLAB: do this loop for the getattr in the annotations class
+            result_dict["annotations"] = {}
+            for annotation in self.annotations:
+                if annotation.data_json is not None:
+                    result_dict["annotations"][annotation.id] = {
+                        "participant": annotation.participant,
+                        "category": annotation.category,
+                        "data": utils.NoIndentJSON(annotation.data_json),
+                    }
 
             prolific_ids = []
+            journeys_global_unique_id = []
             for journey in self.journeys:
                 annotator = journey.annotator
                 if annotator is not None and annotator.prolific_id is not None:
                     prolific_ids.append(annotator.prolific_id)
+                journeys_global_unique_id.append(journey.spec.global_unique_id)
             result_dict["prolific_id"] = prolific_ids
+            result_dict["journeys_global_unique_id"] = journeys_global_unique_id
 
             results_list.append(result_dict)
 

--- a/covfee/server/orm/task.py
+++ b/covfee/server/orm/task.py
@@ -141,22 +141,26 @@ class TaskInstance(NodeInstance):
             # FIXME: #CONFLAB: do this loop for the getattr in the annotations class
             result_dict["annotations"] = {}
             for annotation in self.annotations:
+                annotation_dict = {
+                    "participant": annotation.participant,
+                    "category": annotation.category,
+                }
                 if annotation.data_json is not None:
-                    result_dict["annotations"][annotation.id] = {
-                        "participant": annotation.participant,
-                        "category": annotation.category,
-                        "data": utils.NoIndentJSON(annotation.data_json),
-                    }
+                    annotation_dict["data"] = utils.NoIndentJSON(annotation.data_json)
+                else:
+                    annotation_dict["data"] = None
 
-            prolific_ids = []
-            journeys_global_unique_id = []
+                result_dict["annotations"][annotation.id] = annotation_dict
+
+            result_dict["journeys"] = []
             for journey in self.journeys:
+                journey_dict = {"global_unique_id": journey.spec.global_unique_id}
                 annotator = journey.annotator
                 if annotator is not None and annotator.prolific_id is not None:
-                    prolific_ids.append(annotator.prolific_id)
-                journeys_global_unique_id.append(journey.spec.global_unique_id)
-            result_dict["prolific_id"] = prolific_ids
-            result_dict["journeys_global_unique_id"] = journeys_global_unique_id
+                    journey_dict["prolific_id"] = annotator.prolific_id
+                else:
+                    journey_dict["prolific_id"] = None
+                result_dict["journeys"].append(journey_dict)
 
             results_list.append(result_dict)
 


### PR DESCRIPTION
- Add the global unique ids to the JSON that is downloaded.
- Instead of blindly concatenating the annotations together in a list, store them in a dictionary with the participant name. This ensures there is not mismatch when the data is stored in the JSON.