### PR TITLE
.#61 Assigning study ids to journeys, so journeys are filtered per study

### DIFF
--- a/covfee/launcher.py
+++ b/covfee/launcher.py
@@ -2,26 +2,25 @@ import os
 import platform
 import shutil
 import sys
-from shutil import which
 from datetime import datetime
+from shutil import which
 
 from click import Path
 from colorama import Fore
-from covfee.logger import logger
+from sqlalchemy import Engine
+from sqlalchemy.orm import sessionmaker
 
 import covfee.server.orm as orm
 from covfee.cli.utils import working_directory
 from covfee.config import Config
+from covfee.logger import logger
 from covfee.server.app import create_app_and_socketio
 from covfee.server.db import (
+    DatabaseEngineConfig,
     create_database_engine,
     create_database_sessionmaker,
-    DatabaseEngineConfig,
 )
 from covfee.shared.dataclass import CovfeeApp
-
-from sqlalchemy import Engine
-from sqlalchemy.orm import sessionmaker
 
 
 class ProjectExistsException(Exception):

--- a/covfee/server/orm/annotator.py
+++ b/covfee/server/orm/annotator.py
@@ -1,8 +1,10 @@
+import datetime
+from typing import Optional
+
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-import datetime
+
 from .base import Base
-from typing import Optional
 
 
 class Annotator(Base):
@@ -36,10 +38,6 @@ class Annotator(Base):
         journey_instance_id = (
             self.journey_instance_id.hex() if self.journey_instance_id else "?"
         )
-        expired_journey_instance_id = (
-            self.expired_journey_instance_id.hex()
-            if self.expired_journey_instance_id
-            else "?"
-        )
+
         created_at = self.created_at.isoformat() if self.created_at else "?"
-        return f"Annotator(id={self.id}, prolific_id={self.prolific_id}, journey_instance_id={journey_instance_id}, created_at={created_at}, expired_journey_instance_id={expired_journey_instance_id})"
+        return f"Annotator(id={self.id}, prolific_id={self.prolific_id}, prolific_study_id={self.prolific_study_id}, journey_instance_id={journey_instance_id}, created_at={created_at})"

--- a/covfee/server/orm/journey.py
+++ b/covfee/server/orm/journey.py
@@ -15,10 +15,10 @@ from sqlalchemy import ForeignKey
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from .annotator import Annotator
 from .base import Base
 from .chat import Chat, ChatJourney
 from .node import JourneyNode, JourneySpecNodeSpec
-from .annotator import Annotator
 
 if TYPE_CHECKING:
     from .hit import HITInstance, HITSpec
@@ -35,6 +35,12 @@ class JourneySpec(Base):
     # and thus being able to add more hits/journeys without destroying
     # the database. It's a string as it is intended to be human-readable
     global_unique_id: Mapped[Optional[str]] = mapped_column(unique=True)
+
+    # Indicates whether this journey will be linked to the given study id
+    # from prolific academic, such that when annotators are assigned journeys
+    # , it will only assign journeys corresponding to the same study id as the
+    # incoming annotator.
+    prolific_study_id: Mapped[Optional[str]] = mapped_column()
 
     # spec relationships
     # up
@@ -271,4 +277,7 @@ class JourneyInstance(Base):
         return instance_dict
 
     def make_results_dict(self):
-        return {"nodes": [node.id for node in self.nodes], "global_unique_id": self.spec.global_unique_id}
+        return {
+            "nodes": [node.id for node in self.nodes],
+            "global_unique_id": self.spec.global_unique_id,
+        }

--- a/covfee/server/orm/node.py
+++ b/covfee/server/orm/node.py
@@ -18,8 +18,6 @@ from .condition_parser import eval_string
 if TYPE_CHECKING:
     from .hit import HITInstance, HITSpec
     from .journey import JourneyInstance, JourneySpec
-    from .hit import HITInstance, HITSpec
-    from .journey import JourneyInstance, JourneySpec
 
 
 class JourneySpecNodeSpec(Base):


### PR DESCRIPTION
- Added the prolific_study_id as a new column in the ORM of the JourneySpec
- Now journeys are ignored if their study id does not correspond to the one of the incoming annotator candidate
- Bugfix: In the logic to assign journeys to incoming annotators, we will also filter out those which have 100% progress and consider them as FINISHED because there may be a bug in Covfee and the state is not being changed or the annotators do not click on the corresponding button