### PR TITLE
Solved and now preventing the non-null but empty data_json annotations.

### DIFF
--- a/covfee/client/tasks/continuous_annotation/slice.ts
+++ b/covfee/client/tasks/continuous_annotation/slice.ts
@@ -1,6 +1,10 @@
 import { createSlice } from "@reduxjs/toolkit"
 
 export interface State {
+  // Note: delete selectedAnnotationIndex as state as soon as it is confirmed
+  //       that this not influence the "response" object for an active
+  //       covfee instance. This is because we don't really need it, and using
+  //       it might be a source of bugs due to the use of the custom dispatch.
   selectedAnnotationIndex?: number | null
   mediaPaused: boolean
 }

--- a/covfee/server/orm/task.py
+++ b/covfee/server/orm/task.py
@@ -158,8 +158,10 @@ class TaskInstance(NodeInstance):
                 annotator = journey.annotator
                 if annotator is not None and annotator.prolific_id is not None:
                     journey_dict["prolific_id"] = annotator.prolific_id
+                    journey_dict["prolific_study_id"] = annotator.prolific_study_id
                 else:
                     journey_dict["prolific_id"] = None
+                    journey_dict["prolific_study_id"] = None
                 result_dict["journeys"].append(journey_dict)
 
             results_list.append(result_dict)


### PR DESCRIPTION
- Fixed an issue that when the video failed to load and the user would try to annotate, it would create a data_json array which was non null, but empty. This would then become a "valid" annotation from the point of view of progress and task completion. This should now be prevented.
- Progress is now calculated considering empty arrays as not valid, thus allowing to send again the url to annotators.
- Stopped using the selectedAnnotationIndex from redux, and instead created a useState hook for the continuous annotation task because the custom dispatch appears to break the functionality when the FINISHED state is sent.
- Exporting the prolific_study_id into the results json files